### PR TITLE
Fixed ORA-24435 in multi-threaded scenario

### DIFF
--- a/bndLob.go
+++ b/bndLob.go
@@ -45,7 +45,7 @@ func (bnd *bndLob) bindReader(rdr io.Reader, position int, lobBufferSize int, st
 	}
 
 	if err = writeLob(bnd.ociLobLocator, bnd.stmt, rdr, lobBufferSize); err != nil {
-		bnd.stmt.ses.srv.Break()
+		bnd.stmt.ses.Break()
 		finish()
 		return err
 	}
@@ -77,7 +77,7 @@ func (bnd *bndLob) close() (err error) {
 	// no need to clear bnd.buf
 	// free temporary lob
 	C.OCILobFreeTemporary(
-		bnd.stmt.ses.srv.ocisvcctx,  //OCISvcCtx          *svchp,
+		bnd.stmt.ses.ocisvcctx,      //OCISvcCtx          *svchp,
 		bnd.stmt.ses.srv.env.ocierr, //OCIError           *errhp,
 		bnd.ociLobLocator)           //OCILobLocator      *locp,
 	// free lob locator handle
@@ -181,7 +181,7 @@ func writeLob(ociLobLocator *C.OCILobLocator, stmt *Stmt, r io.Reader, lobBuffer
 		}
 		// Write to Oracle
 		if C.OCILobWrite2(
-			stmt.ses.srv.ocisvcctx,     //OCISvcCtx          *svchp,
+			stmt.ses.ocisvcctx,         //OCISvcCtx          *svchp,
 			stmt.ses.srv.env.ocierr,    //OCIError           *errhp,
 			ociLobLocator,              //OCILobLocator      *locp,
 			&byte_amtp,                 //oraub8          *byte_amtp,
@@ -229,7 +229,7 @@ func allocTempLob(stmt *Stmt) (
 
 	// Create temporary lob
 	r = C.OCILobCreateTemporary(
-		stmt.ses.srv.ocisvcctx,  //OCISvcCtx          *svchp,
+		stmt.ses.ocisvcctx,      //OCISvcCtx          *svchp,
 		stmt.ses.srv.env.ocierr, //OCIError           *errhp,
 		ociLobLocator,           //OCILobLocator      *locp,
 		C.OCI_DEFAULT,           //ub2                csid,
@@ -247,7 +247,7 @@ func allocTempLob(stmt *Stmt) (
 
 	return ociLobLocator, func() {
 		C.OCILobFreeTemporary(
-			stmt.ses.srv.ocisvcctx,  //OCISvcCtx          *svchp,
+			stmt.ses.ocisvcctx,      //OCISvcCtx          *svchp,
 			stmt.ses.srv.env.ocierr, //OCIError           *errhp,
 			ociLobLocator)           //OCILobLocator      *locp,
 		// free lob locator handle

--- a/bndLobPtr.go
+++ b/bndLobPtr.go
@@ -32,7 +32,7 @@ func (bnd *bndLobPtr) bindLob(lob *Lob, position int, lobBufferSize int, stmt *S
 
 	if lob != nil && lob.Reader != nil {
 		if err = writeLob(bnd.ociLobLocator, bnd.stmt, lob.Reader, lobBufferSize); err != nil {
-			bnd.stmt.ses.srv.Break()
+			bnd.stmt.ses.Break()
 			finish()
 			return err
 		}
@@ -51,15 +51,15 @@ func (bnd *bndLobPtr) setPtr() error {
 		return nil
 	}
 	//Log.Infof("setPtr OCILobOpen %p", bnd.ociLobLocator)
-	lobLength, err := lobOpen(bnd.stmt.ses.srv, bnd.ociLobLocator, C.OCI_LOB_READONLY)
+	lobLength, err := lobOpen(bnd.stmt.ses, bnd.ociLobLocator, C.OCI_LOB_READONLY)
 	if err != nil {
-		lobClose(bnd.stmt.ses.srv, bnd.ociLobLocator)
+		lobClose(bnd.stmt.ses, bnd.ociLobLocator)
 		bnd.ociLobLocator = nil
 		return err
 	}
 
 	lr := &lobReader{
-		srv:           bnd.stmt.ses.srv,
+		ses:           bnd.stmt.ses,
 		ociLobLocator: bnd.ociLobLocator,
 		piece:         C.OCI_FIRST_PIECE,
 		Length:        lobLength,
@@ -79,7 +79,7 @@ func (bnd *bndLobPtr) close() (err error) {
 	// no need to clear bnd.buf
 	// free temporary lob
 	C.OCILobFreeTemporary(
-		bnd.stmt.ses.srv.ocisvcctx,  //OCISvcCtx          *svchp,
+		bnd.stmt.ses.ocisvcctx,      //OCISvcCtx          *svchp,
 		bnd.stmt.ses.srv.env.ocierr, //OCIError           *errhp,
 		bnd.ociLobLocator)           //OCILobLocator      *locp,
 	// free lob locator handle

--- a/bndLobSlice.go
+++ b/bndLobSlice.go
@@ -77,7 +77,7 @@ func (bnd *bndLobSlice) bindReaders(
 			continue
 		}
 		if err = writeLob(bnd.ociLobLocators[i], bnd.stmt, r, lobBufferSize); err != nil {
-			bnd.stmt.ses.srv.Break()
+			bnd.stmt.ses.Break()
 			return err
 		}
 	}
@@ -128,7 +128,7 @@ func (bnd *bndLobSlice) close() (err error) {
 	for n := 0; n < len(bnd.ociLobLocators); n++ {
 		// free temporary lob
 		C.OCILobFreeTemporary(
-			bnd.stmt.ses.srv.ocisvcctx,  //OCISvcCtx          *svchp,
+			bnd.stmt.ses.ocisvcctx,      //OCISvcCtx          *svchp,
 			bnd.stmt.ses.srv.env.ocierr, //OCIError           *errhp,
 			bnd.ociLobLocators[n])       //OCILobLocator      *locp,
 		// free lob locator handle

--- a/conn.go
+++ b/conn.go
@@ -142,7 +142,7 @@ func (con *Con) Ping() error {
 	if err := con.checkIsOpen(); err != nil {
 		return err
 	}
-	return con.srv.Ping()
+	return con.ses.Ping()
 }
 
 // sysName returns a string representing the Con.

--- a/doc.go
+++ b/doc.go
@@ -1132,4 +1132,4 @@ Use of this source code is governed by The MIT License
 found in the accompanying LICENSE file.
 
 */
-package ora // import "gopkg.in/rana/ora.v2"
+package ora

--- a/env.go
+++ b/env.go
@@ -140,21 +140,10 @@ func (env *Env) OpenSrv(cfg *SrvCfg) (srv *Srv, err error) {
 	if r == C.OCI_ERROR {
 		return nil, errE(env.ociError())
 	}
-	// allocate service context handle
-	ocisvcctx, err := env.allocOciHandle(C.OCI_HTYPE_SVCCTX)
-	if err != nil {
-		return nil, errE(err)
-	}
-	// set server handle onto service context handle
-	err = env.setAttr(ocisvcctx, C.OCI_HTYPE_SVCCTX, ocisrv, C.ub4(0), C.OCI_ATTR_SERVER)
-	if err != nil {
-		return nil, errE(err)
-	}
 
 	srv = _drv.srvPool.Get().(*Srv) // set *Srv
 	srv.env = env
 	srv.ocisrv = (*C.OCIServer)(ocisrv)
-	srv.ocisvcctx = (*C.OCISvcCtx)(ocisvcctx)
 	if srv.id == 0 {
 		srv.id = _drv.srvId.nextId()
 	}

--- a/ora.go
+++ b/ora.go
@@ -22,7 +22,7 @@ const (
 
 	// The driver version sent to an Oracle server and visible in
 	// V$SESSION_CONNECT_INFO or GV$SESSION_CONNECT_INFO.
-	Version string = "v2.0.0"
+	Version string = "v3.0.0"
 )
 
 var _drv *Drv

--- a/rset.go
+++ b/rset.go
@@ -264,7 +264,7 @@ func (rset *Rset) open(stmt *Stmt, ocistmt *C.OCIStmt) error {
 	rset.log(_drv.cfg.Log.Rset.Open) // call log after rset.stmt is set
 	// get the implcit select-list describe information; no server round-trip
 	r := C.OCIStmtExecute(
-		rset.stmt.ses.srv.ocisvcctx,  //OCISvcCtx           *svchp,
+		rset.stmt.ses.ocisvcctx,  //OCISvcCtx           *svchp,
 		rset.ocistmt,                 //OCIStmt             *stmtp,
 		rset.stmt.ses.srv.env.ocierr, //OCIError            *errhp,
 		C.ub4(1),                     //ub4                 iters,

--- a/stmt.go
+++ b/stmt.go
@@ -190,7 +190,7 @@ func (stmt *Stmt) exe(params []interface{}) (rowsAffected uint64, lastInsertId i
 	}
 	// Execute statement on Oracle server
 	r := C.OCIStmtExecute(
-		stmt.ses.srv.ocisvcctx,  //OCISvcCtx           *svchp,
+		stmt.ses.ocisvcctx,  //OCISvcCtx           *svchp,
 		stmt.ocistmt,            //OCIStmt             *stmtp,
 		stmt.ses.srv.env.ocierr, //OCIError            *errhp,
 		C.ub4(iterations),       //ub4                 iters,
@@ -249,7 +249,7 @@ func (stmt *Stmt) qry(params []interface{}) (rset *Rset, err error) {
 	}
 	// Query statement on Oracle server
 	r := C.OCIStmtExecute(
-		stmt.ses.srv.ocisvcctx,  //OCISvcCtx           *svchp,
+		stmt.ses.ocisvcctx,  //OCISvcCtx           *svchp,
 		stmt.ocistmt,            //OCIStmt             *stmtp,
 		stmt.ses.srv.env.ocierr, //OCIError            *errhp,
 		C.ub4(0),                //ub4                 iters,

--- a/tx.go
+++ b/tx.go
@@ -83,7 +83,7 @@ func (tx *Tx) Commit() (err error) {
 	}
 	defer tx.closeWithRemove()
 	r := C.OCITransCommit(
-		tx.ses.srv.ocisvcctx,  //OCISvcCtx    *svchp,
+		tx.ses.ocisvcctx,  //OCISvcCtx    *svchp,
 		tx.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.OCI_DEFAULT)         //ub4          flags );
 	if r == C.OCI_ERROR {
@@ -110,7 +110,7 @@ func (tx *Tx) Rollback() (err error) {
 	}
 	defer tx.closeWithRemove()
 	r := C.OCITransRollback(
-		tx.ses.srv.ocisvcctx,  //OCISvcCtx    *svchp,
+		tx.ses.ocisvcctx,  //OCISvcCtx    *svchp,
 		tx.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.OCI_DEFAULT)         //ub4          flags );
 	if r == C.OCI_ERROR {


### PR DESCRIPTION
Required moving ocisvcctx from Srv to Ses. 

Srv.Ping was moved to Ses.Ping.
Srv.Break was moved to Ses.Break.

These two method call changes make the branch a breaking changed and is therefore given a new version number for use in gopkg.in.