### PR TITLE
removed gopkg.in reference

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1132,4 +1132,4 @@ Use of this source code is governed by The MIT License
 found in the accompanying LICENSE file.
 
 */
-package ora // import "gopkg.in/rana/ora.v3"
+package ora


### PR DESCRIPTION
causes build failures on windows