### PR TITLE
Remove the need for ora.Register

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,15 +137,7 @@ When using [database/sql](http://golang.org/pkg/database/sql/), the mapping betw
 	³ The Go bool value false is mapped to the zero rune '0'. The Go bool value
 	true is mapped to the one rune '1'.
 
-To register the ora driver for use with `sql.Open`, you have to call `ora.Register`, once before `sql.Open` in your app:
-
-```go
-func init() {
-	ora.Register(nil)
-}
-```
-
-You may specify an optional *DrvCfg to ora.Register to configure various configuration options including statement configuration and Rset configuration.
+You may specify an optional *DrvCfg to ora.SetDrvCfg to configure various configuration options including statement configuration and Rset configuration.
 
 ```go
 func init() {
@@ -153,7 +145,7 @@ func init() {
 	drvCfg.Env.StmtCfg.FalseRune = 'N'
 	drvCfg.Env.StmtCfg.TrueRune = 'Y'
 	drvCfg.Env.StmtCfg.Rset.TrueRune = 'Y'
-	ora.Register(drvCfg)
+	ora.SetDrvCfg(drvCfg)
 }
 ```
 

--- a/doc.go
+++ b/doc.go
@@ -119,22 +119,16 @@ types. The Go-to-Oracle type mapping for database/sql is:
 	³ The Go bool value false is mapped to the zero rune '0'. The Go bool value
 	true is mapped to the one rune '1'.
 
-To register the ora driver for use with sql.Open, you have to call ora.Register
-once before sql.Open in your app:
-
-    func init() {
-		ora.Register(nil)
-	}
-
-You may specify an optional *DrvCfg to ora.Register to configure various
-configuration options including statement configuration and Rset configuration.
+The "ora" driver is automatically registered for use with sql.Open, but you can
+call ora.SetDrvCfg to set the used configuration options including
+statement configuration and Rset configuration.
 
     func init() {
 		drvCfg := ora.NewDrvCfg()
 		drvCfg.Env.StmtCfg.FalseRune = 'N'
 		drvCfg.Env.StmtCfg.TrueRune = 'Y'
 		drvCfg.Env.StmtCfg.Rset.TrueRune = 'Y'
-		ora.Register(drvCfg)
+		ora.SetDrvCfg(drvCfg)
 	}
 
 When configuring the driver for use with database/sql, keep in mind that
@@ -146,13 +140,6 @@ The ora package allows programming with pointers, slices, nullable types,
 numerics of various sizes, Oracle-specific types, Go return type configuration, and
 Oracle abstractions such as environment, server and session. When working with the
 ora package directly, the API is slightly different than database/sql.
-
-To register the ora driver for use with sql.Open, you have to call ora.Register,
-once before sql.Open in your app:
-
-    func init() {
-		ora.Register(nil)
-	}
 
 When using the ora package directly, the mapping between Go types and Oracle types
 may be changed. The Go-to-Oracle type mapping for the ora package is:

--- a/examples/connect/flags.go
+++ b/examples/connect/flags.go
@@ -90,7 +90,6 @@ func GetConnection(dsn string) (*sql.DB, error) {
 		dsn = GetDSN(GetCfg(""))
 	}
 	log.Printf("GetConnection dsn=%v", dsn)
-	oraInit.Do(func() { ora.Register(nil) })
 	conn, err := sql.Open("ora", dsn)
 	if err != nil {
 		return nil, errgo.Notef(err, "dsn=%q", dsn)

--- a/examples/csvload/csvload.go
+++ b/examples/csvload/csvload.go
@@ -35,7 +35,6 @@ import (
 	"github.com/tgulacsi/go/text"
 	"golang.org/x/text/encoding"
 	"gopkg.in/inconshreveable/log15.v2"
-	"gopkg.in/rana/ora.v3"
 )
 
 var Log = log15.New()
@@ -59,7 +58,6 @@ func main() {
 		}
 	}
 
-	ora.Register(nil)
 	db, err := sql.Open("ora", *flagConnect)
 	if err != nil {
 		Log.Crit("connect to db", "dsn", *flagConnect, "error", err)

--- a/ora.go
+++ b/ora.go
@@ -122,29 +122,30 @@ func init() {
 	_drv.defPools[defIdxRowid] = newPool(func() interface{} { return &defRowid{} })
 }
 
-// Register registers the ora database driver with the database/sql package.
-//
-// Call Register once before sql.Open when working with database/sql:
-//
-//	func init() {
-//		ora.Register(nil)
-//	}
-//
-// Register is unnecessary if you're working directly with the ora package.
-func Register(cfg *DrvCfg) {
-	if _drv.sqlPkgEnv == nil {
-		if cfg != nil {
-			_drv.cfg = *cfg
-		}
-		env, err := OpenEnv(nil)
-		if err != nil {
-			errE(err)
-		}
-		// database/sql/driver expects binaryFloat to return float64 (not the Rset default of float32)
-		env.cfg.StmtCfg.Rset.binaryFloat = F64
-		_drv.sqlPkgEnv = env
-		sql.Register(Name, _drv)
+func init() {
+	var err error
+	_drv.sqlPkgEnv, err = OpenEnv(nil)
+	if err != nil {
+		errE(err)
 	}
+	// database/sql/driver expects binaryFloat to return float64 (not the Rset default of float32)
+	_drv.sqlPkgEnv.cfg.StmtCfg.Rset.binaryFloat = F64
+	sql.Register(Name, _drv)
+}
+
+// SetDrvCfg sets the used configuration options for the driver.
+func SetDrvCfg(cfg *DrvCfg) {
+	if cfg == nil {
+		return
+	}
+	_drv.cfg = *cfg
+}
+
+// Register used to register the ora database driver with the database/sql package,
+// but this is automatic now - so this function is deprecated, has the same effect
+// as SetDrvCfg.
+func Register(cfg *DrvCfg) {
+	SetDrvCfg(cfg)
 }
 
 // OpenEnv opens an Oracle environment.

--- a/z_oracle_test.go
+++ b/z_oracle_test.go
@@ -164,7 +164,6 @@ END;`)
 	fmt.Println("Tables dropped.")
 
 	// setup test db
-	ora.Register(nil)
 	testDb, err = sql.Open(ora.Name, testConStr)
 	if err != nil {
 		fmt.Println("initError: ", err)


### PR DESCRIPTION
Move the functionality into init() + SetDrvCfg.
Keep the Register function for API compatibility.

Fixes Issue #41.