### PR TITLE
Rewrite for Go 1.6's stricter C-Go pointer passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1211,6 +1211,15 @@ Run the tests.
 
 [database/sql](http://golang.org/pkg/database/sql/) method `Stmt.QueryRow` is not supported.
 
+Go 1.6 introduced stricter cgo (call C from Go) rules, and introduced runtime checks.
+This is good, as the possibility of C code corrupting Go code is almost completely eliminated,
+but it also means a severe call overhead grow.
+[Sometimes](https://groups.google.com/forum/#!topic/golang-nuts/ccMkPG6Bi5k)
+this can be 22x the go 1.5.3 call time!
+
+So if you need performance more than correctness, start your programs with
+"GODEBUG=cgocheck=0" environment setting.
+
 ##### License #####
 
 Copyright 2014 Rana Ian. All rights reserved.

--- a/bndBfile.go
+++ b/bndBfile.go
@@ -5,8 +5,8 @@
 package ora
 
 /*
-#include <oci.h>
 #include <stdlib.h>
+#include <oci.h>
 #include "version.h"
 */
 import "C"
@@ -20,9 +20,9 @@ import (
 type bndBfile struct {
 	stmt            *Stmt
 	ocibnd          *C.OCIBind
-	ociLobLocator   *C.OCILobLocator
 	cDirectoryAlias *C.char
 	cFilename       *C.char
+	lobLocatorp
 }
 
 func (bnd *bndBfile) bind(value Bfile, position int, stmt *Stmt) error {
@@ -40,11 +40,11 @@ func (bnd *bndBfile) bind(value Bfile, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	// Allocate lob locator handle
 	r := C.OCIDescriptorAlloc(
-		unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv),           //CONST dvoid   *parenth,
-		(*unsafe.Pointer)(unsafe.Pointer(&bnd.ociLobLocator)), //dvoid         **descpp,
-		C.OCI_DTYPE_FILE,                                      //ub4           type,
-		0,                                                     //size_t        xtramem_sz,
-		nil)                                                   //dvoid         **usrmempp);
+		unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv),                  //CONST dvoid   *parenth,
+		(*unsafe.Pointer)(unsafe.Pointer(bnd.lobLocatorp.Pointer())), //dvoid         **descpp,
+		C.OCI_DTYPE_FILE,                                             //ub4           type,
+		0,                                                            //size_t        xtramem_sz,
+		nil)                                                          //dvoid         **usrmempp);
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	} else if r == C.OCI_INVALID_HANDLE {
@@ -52,11 +52,13 @@ func (bnd *bndBfile) bind(value Bfile, position int, stmt *Stmt) error {
 	}
 
 	bnd.cDirectoryAlias = C.CString(value.DirectoryAlias)
+	defer C.free(unsafe.Pointer(bnd.cDirectoryAlias))
 	bnd.cFilename = C.CString(value.Filename)
+	defer C.free(unsafe.Pointer(bnd.cFilename))
 	r = C.OCILobFileSetName(
 		bnd.stmt.ses.srv.env.ocienv,                       //OCIEnv             *envhp,
 		bnd.stmt.ses.srv.env.ocierr,                       //OCIError           *errhp,
-		&bnd.ociLobLocator,                                //OCILobLocator      **filepp,
+		bnd.lobLocatorp.Pointer(),                         //OCILobLocator      **filepp,
 		(*C.OraText)(unsafe.Pointer(bnd.cDirectoryAlias)), //const OraText      *dir_alias,
 		C.ub2(len(value.DirectoryAlias)),                  //ub2                d_length,
 		(*C.OraText)(unsafe.Pointer(bnd.cFilename)),       //const OraText      *filename,
@@ -65,19 +67,19 @@ func (bnd *bndBfile) bind(value Bfile, position int, stmt *Stmt) error {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                                //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),                      //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,                     //OCIError     *errhp,
-		C.ub4(position),                                 //ub4          position,
-		unsafe.Pointer(&bnd.ociLobLocator),              //void         *valuep,
-		C.LENGTH_TYPE(unsafe.Sizeof(bnd.ociLobLocator)), //sb8          value_sz,
-		C.SQLT_FILE,   //ub2          dty,
-		nil,           //void         *indp,
-		nil,           //ub2          *alenp,
-		nil,           //ub2          *rcodep,
-		0,             //ub4          maxarr_len,
-		nil,           //ub4          *curelep,
-		C.OCI_DEFAULT) //ub4          mode );
+		bnd.stmt.ocistmt,                          //OCIStmt      *stmtp,
+		&bnd.ocibnd,                               //OCIBind      **bindpp,
+		bnd.stmt.ses.srv.env.ocierr,               //OCIError     *errhp,
+		C.ub4(position),                           //ub4          position,
+		unsafe.Pointer(bnd.lobLocatorp.Pointer()), //void         *valuep,
+		C.LENGTH_TYPE(bnd.lobLocatorp.Size()),     //sb8          value_sz,
+		C.SQLT_FILE,                               //ub2          dty,
+		nil,                                       //void         *indp,
+		nil,                                       //ub2          *alenp,
+		nil,                                       //ub2          *rcodep,
+		0,                                         //ub4          maxarr_len,
+		nil,                                       //ub4          *curelep,
+		C.OCI_DEFAULT)                             //ub4          mode );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
@@ -88,29 +90,27 @@ func (bnd *bndBfile) setPtr() error {
 	return nil
 }
 
+func (bnd *bndBfile) alloc() {
+}
+
+func (bnd *bndBfile) free() {
+	bnd.lobLocatorp.Free()
+}
+
 func (bnd *bndBfile) close() (err error) {
 	defer func() {
 		if value := recover(); value != nil {
 			err = errR(value)
 		}
 	}()
-	if bnd.cDirectoryAlias != nil {
-		C.free(unsafe.Pointer(bnd.cDirectoryAlias))
-	}
-	if bnd.cFilename != nil {
-		C.free(unsafe.Pointer(bnd.cFilename))
-	}
-	if bnd.ociLobLocator != nil {
+	if lob := bnd.lobLocatorp.Value(); lob != nil {
 		C.OCIDescriptorFree(
-			unsafe.Pointer(bnd.ociLobLocator), //void     *descp,
-			C.OCI_DTYPE_FILE)                  //ub4      type );
+			unsafe.Pointer(lob), //void     *descp,
+			C.OCI_DTYPE_FILE)    //ub4      type );
 	}
 	stmt := bnd.stmt
 	bnd.stmt = nil
 	bnd.ocibnd = nil
-	bnd.ociLobLocator = nil
-	bnd.cDirectoryAlias = nil
-	bnd.cFilename = nil
 	stmt.putBnd(bndIdxBfile, bnd)
 	return nil
 }

--- a/bndBin.go
+++ b/bndBin.go
@@ -5,6 +5,7 @@
 package ora
 
 /*
+#include <stdlib.h>
 #include <oci.h>
 #include "version.h"
 */
@@ -20,7 +21,7 @@ func (bnd *bndBin) bind(value []byte, position int, stmt *Stmt) (err error) {
 	bnd.stmt = stmt
 	r := C.OCIBINDBYPOS(
 		bnd.stmt.ocistmt,            //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),  //OCIBind      **bindpp,
+		&bnd.ocibnd,                 //OCIBind      **bindpp,
 		bnd.stmt.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.ub4(position),             //ub4          position,
 		unsafe.Pointer(&value[0]),   //void         *valuep,
@@ -35,12 +36,14 @@ func (bnd *bndBin) bind(value []byte, position int, stmt *Stmt) (err error) {
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
-
 	return nil
 }
 
 func (bnd *bndBin) setPtr() error {
 	return nil
+}
+
+func (bnd *bndBin) free() {
 }
 
 func (bnd *bndBin) close() (err error) {

--- a/bndBinSlice.go
+++ b/bndBinSlice.go
@@ -61,7 +61,7 @@ func (bnd *bndBinSlice) bind(values [][]byte, nullInds []C.sb2, position int, lo
 	}
 	r := C.OCIBINDBYPOS(
 		bnd.stmt.ocistmt,             //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),   //OCIBind      **bindpp,
+		&bnd.ocibnd,                  //OCIBind      **bindpp,
 		bnd.stmt.ses.srv.env.ocierr,  //OCIError     *errhp,
 		C.ub4(position),              //ub4          position,
 		unsafe.Pointer(&bnd.buf[0]),  //void         *valuep,

--- a/bndBool.go
+++ b/bndBool.go
@@ -36,7 +36,7 @@ func (bnd *bndBool) bind(value bool, position int, c StmtCfg, stmt *Stmt) (err e
 	bnd.cString = C.CString(str)
 	r := C.OCIBINDBYPOS(
 		bnd.stmt.ocistmt,            //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),  //OCIBind      **bindpp,
+		&bnd.ocibnd,                 //OCIBind      **bindpp,
 		bnd.stmt.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.ub4(position),             //ub4          position,
 		unsafe.Pointer(bnd.cString), //void         *valuep,

--- a/bndBoolPtr.go
+++ b/bndBoolPtr.go
@@ -17,10 +17,10 @@ import (
 type bndBoolPtr struct {
 	stmt     *Stmt
 	ocibnd   *C.OCIBind
-	isNull   C.sb2
 	value    *bool
 	buf      []byte
 	trueRune rune
+	nullp
 }
 
 func (bnd *bndBoolPtr) bind(value *bool, position int, trueRune rune, stmt *Stmt) error {
@@ -33,14 +33,14 @@ func (bnd *bndBoolPtr) bind(value *bool, position int, trueRune rune, stmt *Stmt
 	}
 	// FIXME(tgulacsi): bnd.buf should be populated with *value!
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,            //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),  //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr, //OCIError     *errhp,
-		C.ub4(position),             //ub4          position,
-		unsafe.Pointer(&bnd.buf[0]), //void         *valuep,
-		C.LENGTH_TYPE(len(bnd.buf)), //sb8          value_sz,
-		C.SQLT_CHR,                  //ub2          dty,
-		unsafe.Pointer(&bnd.isNull), //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.buf[0]),         //void         *valuep,
+		C.LENGTH_TYPE(len(bnd.buf)),         //sb8          value_sz,
+		C.SQLT_CHR,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -54,7 +54,7 @@ func (bnd *bndBoolPtr) bind(value *bool, position int, trueRune rune, stmt *Stmt
 
 func (bnd *bndBoolPtr) setPtr() error {
 	//Log.Infof("%s.setPtr()", bnd)
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r, _ := utf8.DecodeRune(bnd.buf)
 		*bnd.value = r == bnd.trueRune
 	} else {
@@ -74,6 +74,7 @@ func (bnd *bndBoolPtr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	clear(bnd.buf, 0)
 	stmt.putBnd(bndIdxBoolPtr, bnd)
 	return nil

--- a/bndBoolSlice.go
+++ b/bndBoolSlice.go
@@ -59,8 +59,8 @@ func (bnd *bndBoolSlice) bind(values []bool, nullInds []C.sb2, position int, fal
 	bnd.bytes = bnd.buf.Bytes()
 
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,              //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),    //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,   //OCIError     *errhp,
 		C.ub4(position),               //ub4          position,
 		unsafe.Pointer(&bnd.bytes[0]), //void         *valuep,

--- a/bndFloat32.go
+++ b/bndFloat32.go
@@ -16,7 +16,7 @@ import (
 type bndFloat32 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndFloat32) bind(value float32, position int, stmt *Stmt) error {
@@ -24,17 +24,17 @@ func (bnd *bndFloat32) bind(value float32, position int, stmt *Stmt) error {
 	r := C.OCINumberFromReal(
 		bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 		unsafe.Pointer(&value),      //const void          *rnum,
-		4,              //uword               rnum_length,
-		&bnd.ociNumber) //OCINumber           *number );
+		4,                 //uword               rnum_length,
+		&bnd.ociNumber[0]) //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndFloat32Ptr.go
+++ b/bndFloat32Ptr.go
@@ -16,35 +16,34 @@ import (
 type bndFloat32Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *float32
+	nullp
 }
 
 func (bnd *bndFloat32Ptr) bind(value *float32, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromReal(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *rnum,
-			4,              //uword               rnum_length,
-			&bnd.ociNumber) //OCINumber           *number );
+			4,                 //uword               rnum_length,
+			&bnd.ociNumber[0]) //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -57,10 +56,10 @@ func (bnd *bndFloat32Ptr) bind(value *float32, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndFloat32Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToReal(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber     *number,
+			&bnd.ociNumber[0],           //const OCINumber     *number,
 			C.uword(4),                  //uword               rsl_length,
 			unsafe.Pointer(bnd.value))   //void                *rsl );
 		if r == C.OCI_ERROR {
@@ -81,6 +80,7 @@ func (bnd *bndFloat32Ptr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxFloat32Ptr, bnd)
 	return nil
 }

--- a/bndFloat64.go
+++ b/bndFloat64.go
@@ -16,7 +16,7 @@ import (
 type bndFloat64 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndFloat64) bind(value float64, position int, stmt *Stmt) error {
@@ -24,17 +24,17 @@ func (bnd *bndFloat64) bind(value float64, position int, stmt *Stmt) error {
 	r := C.OCINumberFromReal(
 		bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 		unsafe.Pointer(&value),      //const void          *rnum,
-		8,              //uword               rnum_length,
-		&bnd.ociNumber) //OCINumber           *number );
+		8,                 //uword               rnum_length,
+		&bnd.ociNumber[0]) //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndFloat64Ptr.go
+++ b/bndFloat64Ptr.go
@@ -16,35 +16,34 @@ import (
 type bndFloat64Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *float64
+	nullp
 }
 
 func (bnd *bndFloat64Ptr) bind(value *float64, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromReal(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *rnum,
-			8,              //uword               rnum_length,
-			&bnd.ociNumber) //OCINumber           *number );
+			8,                 //uword               rnum_length,
+			&bnd.ociNumber[0]) //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -57,10 +56,10 @@ func (bnd *bndFloat64Ptr) bind(value *float64, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndFloat64Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToReal(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber     *number,
+			&bnd.ociNumber[0],           //const OCINumber     *number,
 			C.uword(8),                  //uword               rsl_length,
 			unsafe.Pointer(bnd.value))   //void                *rsl );
 		if r == C.OCI_ERROR {
@@ -81,6 +80,7 @@ func (bnd *bndFloat64Ptr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxFloat64Ptr, bnd)
 	return nil
 }

--- a/bndFloat64Slice.go
+++ b/bndFloat64Slice.go
@@ -7,6 +7,7 @@ package ora
 /*
 #include <oci.h>
 #include "version.h"
+
 */
 import "C"
 import (
@@ -40,20 +41,22 @@ func (bnd *bndFloat64Slice) bind(values []float64, nullInds []C.sb2, position in
 	alenp := make([]C.ACTUAL_LENGTH_TYPE, len(values))
 	rcodep := make([]C.ub2, len(values))
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
+	alen := C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
 	for n := range values {
-		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromReal(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *rnum,
-			8,                  //uword               rnum_length,
-			&bnd.ociNumbers[n]) //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+		alenp[n] = alen
+	}
+	if r := C.numberFromFloatSlice(
+		bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
+		unsafe.Pointer(&values[0]),  //const void          *rnum,
+		8,                  //uword               rnum_length,
+		&bnd.ociNumbers[0], //OCINumber           *number
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bndInt16.go
+++ b/bndInt16.go
@@ -16,7 +16,7 @@ import (
 type bndInt16 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndInt16) bind(value int16, position int, stmt *Stmt) error {
@@ -26,16 +26,16 @@ func (bnd *bndInt16) bind(value int16, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		2,                   //uword               inum_length,
 		C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)      //OCINumber           *number );
+		&bnd.ociNumber[0])   //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndInt16Ptr.go
+++ b/bndInt16Ptr.go
@@ -16,36 +16,35 @@ import (
 type bndInt16Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *int16
+	nullp
 }
 
 func (bnd *bndInt16Ptr) bind(value *int16, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *inum,
 			2,                   //uword               inum_length,
 			C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-			&bnd.ociNumber)      //OCINumber           *number );
+			&bnd.ociNumber[0])   //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -58,10 +57,10 @@ func (bnd *bndInt16Ptr) bind(value *int16, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndInt16Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber       *number,
+			&bnd.ociNumber[0],           //const OCINumber       *number,
 			C.uword(2),                  //uword                 rsl_length,
 			C.OCI_NUMBER_SIGNED,         //uword                 rsl_flag,
 			unsafe.Pointer(bnd.value))   //void                  *rsl );

--- a/bndInt16Slice.go
+++ b/bndInt16Slice.go
@@ -42,19 +42,20 @@ func (bnd *bndInt16Slice) bind(values []int16, nullInds []C.sb2, position int, s
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
 	for n := range values {
 		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromInt(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *inum,
-			2,                   //uword               inum_length,
-			C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-			&bnd.ociNumbers[n])  //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+	}
+	if r := C.numberFromIntSlice(
+		bnd.stmt.ses.srv.env.ocierr,
+		unsafe.Pointer(&values[0]),
+		2,
+		C.OCI_NUMBER_SIGNED,
+		&bnd.ociNumbers[0],
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bndInt32.go
+++ b/bndInt32.go
@@ -16,7 +16,7 @@ import (
 type bndInt32 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndInt32) bind(value int32, position int, stmt *Stmt) error {
@@ -26,16 +26,16 @@ func (bnd *bndInt32) bind(value int32, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		4,                   //uword               inum_length,
 		C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)      //OCINumber           *number );
+		&bnd.ociNumber[0])   //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndInt32Ptr.go
+++ b/bndInt32Ptr.go
@@ -16,38 +16,37 @@ import (
 type bndInt32Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *int32
+	nullp
 }
 
 func (bnd *bndInt32Ptr) bind(value *int32, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *inum,
 			4,                   //uword               inum_length,
 			C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-			&bnd.ociNumber)      //OCINumber           *number
+			&bnd.ociNumber[0])   //OCINumber           *number
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 		bnd.stmt.logF(_drv.cfg.Log.Stmt.Bind,
-			"Int32Ptr.bind(%d) value=%d => number=%#v", position, *value, bnd.ociNumber)
+			"Int32Ptr.bind(%d) value=%d => number=%#v", position, *value, bnd.ociNumber[0])
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -60,18 +59,18 @@ func (bnd *bndInt32Ptr) bind(value *int32, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndInt32Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber       *number,
-			C.uword(4),                  //uword                 rsl_length,
+			&bnd.ociNumber[0],           //const OCINumber       *number,
+			4,                           //uword                 rsl_length,
 			C.OCI_NUMBER_SIGNED,         //uword                 rsl_flag,
 			unsafe.Pointer(bnd.value))   //void                  *rsl );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 		bnd.stmt.logF(_drv.cfg.Log.Stmt.Bind,
-			"Int32Ptr.setPtr number=%#v => value=%d", bnd.ociNumber, *bnd.value)
+			"Int32Ptr.setPtr number=%#v => value=%d", bnd.ociNumber[0], *bnd.value)
 	}
 	return nil
 }

--- a/bndInt32Slice.go
+++ b/bndInt32Slice.go
@@ -42,19 +42,20 @@ func (bnd *bndInt32Slice) bind(values []int32, nullInds []C.sb2, position int, s
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
 	for n := range values {
 		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromInt(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *inum,
-			4,                   //uword               inum_length,
-			C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-			&bnd.ociNumbers[n])  //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+	}
+	if r := C.numberFromIntSlice(
+		bnd.stmt.ses.srv.env.ocierr,
+		unsafe.Pointer(&values[0]),
+		4,
+		C.OCI_NUMBER_SIGNED,
+		&bnd.ociNumbers[0],
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bndInt64.go
+++ b/bndInt64.go
@@ -9,14 +9,12 @@ package ora
 #include "version.h"
 */
 import "C"
-import (
-	"unsafe"
-)
+import "unsafe"
 
 type bndInt64 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndInt64) bind(value int64, position int, stmt *Stmt) error {
@@ -26,16 +24,16 @@ func (bnd *bndInt64) bind(value int64, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		8,                   //uword               inum_length,
 		C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)      //OCINumber           *number );
+		&bnd.ociNumber[0])   //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndInt64Ptr.go
+++ b/bndInt64Ptr.go
@@ -9,45 +9,42 @@ package ora
 #include "version.h"
 */
 import "C"
-import (
-	"unsafe"
-)
+import "unsafe"
 
 type bndInt64Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *int64
+	nullp
 }
 
 func (bnd *bndInt64Ptr) bind(value *int64, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *inum,
 			8,                   //uword               inum_length,
 			C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-			&bnd.ociNumber)      //OCINumber           *number );
+			&bnd.ociNumber[0])   //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 		bnd.stmt.logF(_drv.cfg.Log.Stmt.Bind,
-			"Int64Ptr.bind(%d) value=%d => number=%#v", position, *value, bnd.ociNumber)
+			"Int64Ptr.bind(%d) value=%d => number=%#v", position, *value, bnd.ociNumber[0])
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -60,11 +57,11 @@ func (bnd *bndInt64Ptr) bind(value *int64, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndInt64Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber       *number,
-			C.uword(8),                  //uword                 rsl_length,
+			&bnd.ociNumber[0],           //const OCINumber       *number,
+			8,                           //uword                 rsl_length,
 			C.OCI_NUMBER_SIGNED,         //uword                 rsl_flag,
 			unsafe.Pointer(bnd.value))   //void                  *rsl );
 		if r == C.OCI_ERROR {
@@ -85,6 +82,7 @@ func (bnd *bndInt64Ptr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxInt64Ptr, bnd)
 	return nil
 }

--- a/bndInt8.go
+++ b/bndInt8.go
@@ -16,7 +16,7 @@ import (
 type bndInt8 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndInt8) bind(value int8, position int, stmt *Stmt) error {
@@ -26,16 +26,16 @@ func (bnd *bndInt8) bind(value int8, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		1,                   //uword               inum_length,
 		C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)      //OCINumber           *number );
+		&bnd.ociNumber[0])   //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndInt8Ptr.go
+++ b/bndInt8Ptr.go
@@ -16,36 +16,35 @@ import (
 type bndInt8Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *int8
+	nullp
 }
 
 func (bnd *bndInt8Ptr) bind(value *int8, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *inum,
 			1,                   //uword               inum_length,
 			C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-			&bnd.ociNumber)      //OCINumber           *number );
+			&bnd.ociNumber[0])   //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -58,11 +57,11 @@ func (bnd *bndInt8Ptr) bind(value *int8, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndInt8Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber       *number,
-			C.uword(1),                  //uword                 rsl_length,
+			&bnd.ociNumber[0],           //const OCINumber       *number,
+			1,                           //uword                 rsl_length,
 			C.OCI_NUMBER_SIGNED,         //uword                 rsl_flag,
 			unsafe.Pointer(bnd.value))   //void                  *rsl );
 		if r == C.OCI_ERROR {
@@ -83,6 +82,7 @@ func (bnd *bndInt8Ptr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxInt8Ptr, bnd)
 	return nil
 }

--- a/bndInt8Slice.go
+++ b/bndInt8Slice.go
@@ -42,19 +42,20 @@ func (bnd *bndInt8Slice) bind(values []int8, nullInds []C.sb2, position int, stm
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
 	for n := range values {
 		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromInt(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *inum,
-			1,                   //uword               inum_length,
-			C.OCI_NUMBER_SIGNED, //uword               inum_s_flag,
-			&bnd.ociNumbers[n])  //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+	}
+	if r := C.numberFromIntSlice(
+		bnd.stmt.ses.srv.env.ocierr,
+		unsafe.Pointer(&values[0]),
+		1,
+		C.OCI_NUMBER_SIGNED,
+		&bnd.ociNumbers[0],
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bndIntervalDS.go
+++ b/bndIntervalDS.go
@@ -14,17 +14,17 @@ import (
 )
 
 type bndIntervalDS struct {
-	stmt        *Stmt
-	ocibnd      *C.OCIBind
-	ociInterval *C.OCIInterval
+	stmt   *Stmt
+	ocibnd *C.OCIBind
+	intervalp
 }
 
 func (bnd *bndIntervalDS) bind(value IntervalDS, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	r := C.OCIDescriptorAlloc(
-		unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv),         //CONST dvoid   *parenth,
-		(*unsafe.Pointer)(unsafe.Pointer(&bnd.ociInterval)), //dvoid         **descpp,
-		C.OCI_DTYPE_INTERVAL_DS,                             //ub4           type,
+		unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv),                //CONST dvoid   *parenth,
+		(*unsafe.Pointer)(unsafe.Pointer(bnd.intervalp.Pointer())), //dvoid         **descpp,
+		C.OCI_DTYPE_INTERVAL_DS,                                    //ub4           type,
 		0,   //size_t        xtramem_sz,
 		nil) //dvoid         **usrmempp);
 	if r == C.OCI_ERROR {
@@ -40,24 +40,24 @@ func (bnd *bndIntervalDS) bind(value IntervalDS, position int, stmt *Stmt) error
 		C.sb4(value.Minute),                         //sb4                mm,
 		C.sb4(value.Second),                         //sb4                ss,
 		C.sb4(value.Nanosecond),                     //sb4                fsec,
-		bnd.ociInterval)                             //OCIInterval        *result );
+		bnd.intervalp.Value())                       //OCIInterval        *result );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                              //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),                    //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,                   //OCIError     *errhp,
-		C.ub4(position),                               //ub4          position,
-		unsafe.Pointer(&bnd.ociInterval),              //void         *valuep,
-		C.LENGTH_TYPE(unsafe.Sizeof(bnd.ociInterval)), //sb8          value_sz,
-		C.SQLT_INTERVAL_DS,                            //ub2          dty,
-		nil,                                           //void         *indp,
-		nil,                                           //ub2          *alenp,
-		nil,                                           //ub2          *rcodep,
-		0,                                             //ub4          maxarr_len,
-		nil,                                           //ub4          *curelep,
-		C.OCI_DEFAULT)                                 //ub4          mode );
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,             //OCIError     *errhp,
+		C.ub4(position),                         //ub4          position,
+		unsafe.Pointer(bnd.intervalp.Pointer()), //void         *valuep,
+		C.LENGTH_TYPE(bnd.intervalp.Size()),     //sb8          value_sz,
+		C.SQLT_INTERVAL_DS,                      //ub2          dty,
+		nil,                                     //void         *indp,
+		nil,                                     //ub2          *alenp,
+		nil,                                     //ub2          *rcodep,
+		0,                                       //ub4          maxarr_len,
+		nil,                                     //ub4          *curelep,
+		C.OCI_DEFAULT)                           //ub4          mode );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
@@ -76,12 +76,12 @@ func (bnd *bndIntervalDS) close() (err error) {
 	}()
 
 	C.OCIDescriptorFree(
-		unsafe.Pointer(bnd.ociInterval), //void     *descp,
-		C.OCI_DTYPE_INTERVAL_DS)         //timeDefine.descTypeCode)
+		unsafe.Pointer(bnd.intervalp.Pointer()), //void     *descp,
+		C.OCI_DTYPE_INTERVAL_DS)                 //timeDefine.descTypeCode)
 	stmt := bnd.stmt
 	bnd.stmt = nil
 	bnd.ocibnd = nil
-	bnd.ociInterval = nil
+	bnd.intervalp.Free()
 	stmt.putBnd(bndIdxIntervalDS, bnd)
 	return nil
 }

--- a/bndIntervalYMSlice.go
+++ b/bndIntervalYMSlice.go
@@ -25,19 +25,28 @@ func (bnd *bndIntervalYMSlice) bind(values []IntervalYM, position int, stmt *Stm
 	nullInds := make([]C.sb2, len(values))
 	alenp := make([]C.ACTUAL_LENGTH_TYPE, len(values))
 	rcodep := make([]C.ub2, len(values))
+	alen := C.ACTUAL_LENGTH_TYPE(unsafe.Sizeof(bnd.ociIntervals[0]))
+
+	if r := C.decriptorAllocSlice(
+		bnd.stmt.ses.srv.env.ocienv,          //CONST dvoid   *parenth,
+		unsafe.Pointer(&bnd.ociIntervals[0]), //dvoid         **descpp,
+		C.ub4(alen),
+		C.OCI_DTYPE_INTERVAL_YM, //ub4           type,
+		C.size_t(len(values)),   //size_t        xtramem_sz,
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
+	} else if r == C.OCI_INVALID_HANDLE {
+		return errNew("unable to allocate oci interval handle during bind")
+	}
+
 	for n, value := range values {
-		r := C.OCIDescriptorAlloc(
-			unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv),             //CONST dvoid   *parenth,
-			(*unsafe.Pointer)(unsafe.Pointer(&bnd.ociIntervals[n])), //dvoid         **descpp,
-			C.OCI_DTYPE_INTERVAL_YM,                                 //ub4           type,
-			0,   //size_t        xtramem_sz,
-			nil) //dvoid         **usrmempp);
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		} else if r == C.OCI_INVALID_HANDLE {
-			return errNew("unable to allocate oci interval handle during bind")
+		if values[n].IsNull {
+			nullInds[n] = C.sb2(-1)
+		} else {
+			nullInds[n] = C.sb2(0)
 		}
-		r = C.OCIIntervalSetYearMonth(
+		alenp[n] = alen
+		r := C.OCIIntervalSetYearMonth(
 			unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv), //void               *hndl,
 			bnd.stmt.ses.srv.env.ocierr,                 //OCIError           *err,
 			C.sb4(value.Year),                           //sb4                yr,
@@ -46,16 +55,10 @@ func (bnd *bndIntervalYMSlice) bind(values []IntervalYM, position int, stmt *Stm
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
-		if values[n].IsNull {
-			nullInds[n] = C.sb2(-1)
-		} else {
-			nullInds[n] = C.sb2(0)
-		}
-		alenp[n] = C.ACTUAL_LENGTH_TYPE(unsafe.Sizeof(bnd.ociIntervals[n]))
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),                        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,                       //OCIError     *errhp,
 		C.ub4(position),                                   //ub4          position,
 		unsafe.Pointer(&bnd.ociIntervals[0]),              //void         *valuep,

--- a/bndLobSlice.go
+++ b/bndLobSlice.go
@@ -83,8 +83,8 @@ func (bnd *bndLobSlice) bindReaders(
 	}
 
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                                    //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),                          //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,                         //OCIError     *errhp,
 		C.ub4(position),                                     //ub4          position,
 		unsafe.Pointer(&bnd.ociLobLocators[0]),              //void         *valuep,

--- a/bndNil.go
+++ b/bndNil.go
@@ -23,7 +23,7 @@ func (bnd *bndNil) bind(position int, sqlt C.ub2, stmt *Stmt) error {
 	indp := C.sb2(-1)
 	r := C.OCIBINDBYPOS(
 		bnd.stmt.ocistmt,            //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),  //OCIBind      **bindpp,
+		&bnd.ocibnd,                 //OCIBind      **bindpp,
 		bnd.stmt.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.ub4(position),             //ub4          position,
 		nil,                         //void         *valuep,

--- a/bndString.go
+++ b/bndString.go
@@ -25,7 +25,7 @@ func (bnd *bndString) bind(value string, position int, stmt *Stmt) error {
 	bnd.cString = C.CString(value)
 	r := C.OCIBINDBYPOS(
 		bnd.stmt.ocistmt,            //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),  //OCIBind      **bindpp,
+		&bnd.ocibnd,                 //OCIBind      **bindpp,
 		bnd.stmt.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.ub4(position),             //ub4          position,
 		unsafe.Pointer(bnd.cString), //void         *valuep,
@@ -53,7 +53,9 @@ func (bnd *bndString) close() (err error) {
 			err = errR(value)
 		}
 	}()
-	C.free(unsafe.Pointer(bnd.cString))
+	if bnd.cString != nil {
+		C.free(unsafe.Pointer(bnd.cString))
+	}
 	stmt := bnd.stmt
 	bnd.stmt = nil
 	bnd.ocibnd = nil

--- a/bndStringSlice.go
+++ b/bndStringSlice.go
@@ -66,7 +66,7 @@ func (bnd *bndStringSlice) bind(values []string, nullInds []C.sb2, position int,
 	bnd.bytes = bnd.buf.Bytes()
 	r := C.OCIBINDBYPOS(
 		bnd.stmt.ocistmt,              //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),    //OCIBind      **bindpp,
+		&bnd.ocibnd,                   //OCIBind      **bindpp,
 		bnd.stmt.ses.srv.env.ocierr,   //OCIError     *errhp,
 		C.ub4(position),               //ub4          position,
 		unsafe.Pointer(&bnd.bytes[0]), //void         *valuep,

--- a/bndTimePtr.go
+++ b/bndTimePtr.go
@@ -17,22 +17,22 @@ import (
 )
 
 type bndTimePtr struct {
-	stmt        *Stmt
-	ocibnd      *C.OCIBind
-	ociDateTime *C.OCIDateTime
-	isNull      C.sb2
-	value       *time.Time
-	cZone       *C.char
-	zoneBuf     bytes.Buffer
+	stmt    *Stmt
+	ocibnd  *C.OCIBind
+	value   *time.Time
+	cZone   *C.char
+	zoneBuf bytes.Buffer
+	dateTimep
+	nullp
 }
 
 func (bnd *bndTimePtr) bind(value *time.Time, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
 	r := C.OCIDescriptorAlloc(
-		unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv),         //CONST dvoid   *parenth,
-		(*unsafe.Pointer)(unsafe.Pointer(&bnd.ociDateTime)), //dvoid         **descpp,
-		C.OCI_DTYPE_TIMESTAMP_TZ,                            //ub4           type,
+		unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv),                //CONST dvoid   *parenth,
+		(*unsafe.Pointer)(unsafe.Pointer(bnd.dateTimep.Pointer())), //dvoid         **descpp,
+		C.OCI_DTYPE_TIMESTAMP_TZ,                                   //ub4           type,
 		0,   //size_t        xtramem_sz,
 		nil) //dvoid         **usrmempp);
 	if r == C.OCI_ERROR {
@@ -40,15 +40,14 @@ func (bnd *bndTimePtr) bind(value *time.Time, position int, stmt *Stmt) error {
 	} else if r == C.OCI_INVALID_HANDLE {
 		return errNew("unable to allocate oci timestamp handle during bind")
 	}
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		zone := zoneOffset(*value, &bnd.zoneBuf)
 		bnd.cZone = C.CString(zone)
 		r = C.OCIDateTimeConstruct(
 			unsafe.Pointer(bnd.stmt.ses.srv.env.ocienv), //dvoid         *hndl,
 			bnd.stmt.ses.srv.env.ocierr,                 //OCIError      *err,
-			bnd.ociDateTime,                             //OCIDateTime   *datetime,
+			bnd.dateTimep.Value(),                       //OCIDateTime   *datetime,
 			C.sb2(value.Year()),                         //sb2           year,
 			C.ub1(int32(value.Month())),                 //ub1           month,
 			C.ub1(value.Day()),                          //ub1           day,
@@ -63,14 +62,14 @@ func (bnd *bndTimePtr) bind(value *time.Time, position int, stmt *Stmt) error {
 		}
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                              //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),                    //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,                   //OCIError     *errhp,
-		C.ub4(position),                               //ub4          position,
-		unsafe.Pointer(&bnd.ociDateTime),              //void         *valuep,
-		C.LENGTH_TYPE(unsafe.Sizeof(bnd.ociDateTime)), //sb8          value_sz,
-		C.SQLT_TIMESTAMP_TZ,                           //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),                   //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,             //OCIError     *errhp,
+		C.ub4(position),                         //ub4          position,
+		unsafe.Pointer(bnd.dateTimep.Pointer()), //void         *valuep,
+		C.LENGTH_TYPE(bnd.dateTimep.Size()),     //sb8          value_sz,
+		C.SQLT_TIMESTAMP_TZ,                     //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()),     //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -83,8 +82,8 @@ func (bnd *bndTimePtr) bind(value *time.Time, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndTimePtr) setPtr() (err error) {
-	if bnd.value != nil && bnd.isNull > C.sb2(-1) {
-		*bnd.value, err = getTime(bnd.stmt.ses.srv.env, bnd.ociDateTime)
+	if bnd.value != nil && !bnd.nullp.IsNull() {
+		*bnd.value, err = getTime(bnd.stmt.ses.srv.env, bnd.dateTimep.Value())
 	}
 	return err
 }
@@ -100,15 +99,16 @@ func (bnd *bndTimePtr) close() (err error) {
 		C.free(unsafe.Pointer(bnd.cZone))
 		bnd.cZone = nil
 		C.OCIDescriptorFree(
-			unsafe.Pointer(bnd.ociDateTime), //void     *descp,
-			C.OCI_DTYPE_TIMESTAMP_TZ)        //ub4      type );
+			unsafe.Pointer(bnd.dateTimep.Value()), //void     *descp,
+			C.OCI_DTYPE_TIMESTAMP_TZ)              //ub4      type );
 	}
 	stmt := bnd.stmt
 	bnd.stmt = nil
 	bnd.ocibnd = nil
-	bnd.ociDateTime = nil
 	bnd.value = nil
 	bnd.zoneBuf.Reset()
+	bnd.dateTimep.Free()
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxTimePtr, bnd)
 	return nil
 }

--- a/bndTimeSlice.go
+++ b/bndTimeSlice.go
@@ -82,7 +82,7 @@ func (bnd *bndTimeSlice) bind(values []time.Time, nullInds []C.sb2, position int
 
 	r := C.OCIBINDBYPOS(
 		bnd.stmt.ocistmt,                                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),                        //OCIBind      **bindpp,
+		&bnd.ocibnd,                                       //OCIBind      **bindpp,
 		bnd.stmt.ses.srv.env.ocierr,                       //OCIError     *errhp,
 		C.ub4(position),                                   //ub4          position,
 		unsafe.Pointer(&bnd.ociDateTimes[0]),              //void         *valuep,

--- a/bndUint16.go
+++ b/bndUint16.go
@@ -16,7 +16,7 @@ import (
 type bndUint16 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndUint16) bind(value uint16, position int, stmt *Stmt) error {
@@ -26,16 +26,16 @@ func (bnd *bndUint16) bind(value uint16, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		2, //uword               inum_length,
 		C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)        //OCINumber           *number );
+		&bnd.ociNumber[0])     //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndUint16Ptr.go
+++ b/bndUint16Ptr.go
@@ -16,36 +16,35 @@ import (
 type bndUint16Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *uint16
+	nullp
 }
 
 func (bnd *bndUint16Ptr) bind(value *uint16, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *inum,
 			2, //uword               inum_length,
 			C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-			&bnd.ociNumber)        //OCINumber           *number );
+			&bnd.ociNumber[0])     //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -58,10 +57,10 @@ func (bnd *bndUint16Ptr) bind(value *uint16, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndUint16Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber       *number,
+			&bnd.ociNumber[0],           //const OCINumber       *number,
 			C.uword(2),                  //uword                 rsl_length,
 			C.OCI_NUMBER_UNSIGNED,       //uword                 rsl_flag,
 			unsafe.Pointer(bnd.value))   //void                  *rsl );
@@ -83,6 +82,7 @@ func (bnd *bndUint16Ptr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxUint16Ptr, bnd)
 	return nil
 }

--- a/bndUint16Slice.go
+++ b/bndUint16Slice.go
@@ -42,19 +42,20 @@ func (bnd *bndUint16Slice) bind(values []uint16, nullInds []C.sb2, position int,
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
 	for n := range values {
 		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromInt(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *inum,
-			2, //uword               inum_length,
-			C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-			&bnd.ociNumbers[n])    //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+	}
+	if r := C.numberFromIntSlice(
+		bnd.stmt.ses.srv.env.ocierr,
+		unsafe.Pointer(&values[0]),
+		2,
+		C.OCI_NUMBER_UNSIGNED,
+		&bnd.ociNumbers[0],
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bndUint32.go
+++ b/bndUint32.go
@@ -16,7 +16,7 @@ import (
 type bndUint32 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndUint32) bind(value uint32, position int, stmt *Stmt) error {
@@ -26,16 +26,16 @@ func (bnd *bndUint32) bind(value uint32, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		4, //uword               inum_length,
 		C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)        //OCINumber           *number );
+		&bnd.ociNumber[0])     //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndUint32Ptr.go
+++ b/bndUint32Ptr.go
@@ -16,36 +16,35 @@ import (
 type bndUint32Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *uint32
+	nullp
 }
 
 func (bnd *bndUint32Ptr) bind(value *uint32, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *inum,
 			4, //uword               inum_length,
 			C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-			&bnd.ociNumber)        //OCINumber           *number );
+			&bnd.ociNumber[0])     //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -58,10 +57,10 @@ func (bnd *bndUint32Ptr) bind(value *uint32, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndUint32Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.nullp.IsNull() {
 		r := C.OCINumberToInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber       *number,
+			&bnd.ociNumber[0],           //const OCINumber       *number,
 			C.uword(4),                  //uword                 rsl_length,
 			C.OCI_NUMBER_UNSIGNED,       //uword                 rsl_flag,
 			unsafe.Pointer(bnd.value))   //void                  *rsl );
@@ -83,6 +82,7 @@ func (bnd *bndUint32Ptr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxUint32Ptr, bnd)
 	return nil
 }

--- a/bndUint32Slice.go
+++ b/bndUint32Slice.go
@@ -42,19 +42,20 @@ func (bnd *bndUint32Slice) bind(values []uint32, nullInds []C.sb2, position int,
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
 	for n := range values {
 		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromInt(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *inum,
-			4, //uword               inum_length,
-			C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-			&bnd.ociNumbers[n])    //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+	}
+	if r := C.numberFromIntSlice(
+		bnd.stmt.ses.srv.env.ocierr,
+		unsafe.Pointer(&values[0]),
+		4,
+		C.OCI_NUMBER_UNSIGNED,
+		&bnd.ociNumbers[0],
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bndUint64.go
+++ b/bndUint64.go
@@ -16,7 +16,7 @@ import (
 type bndUint64 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndUint64) bind(value uint64, position int, stmt *Stmt) error {
@@ -26,16 +26,16 @@ func (bnd *bndUint64) bind(value uint64, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		8, //uword               inum_length,
 		C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)        //OCINumber           *number );
+		&bnd.ociNumber[0])     //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndUint64Slice.go
+++ b/bndUint64Slice.go
@@ -42,19 +42,20 @@ func (bnd *bndUint64Slice) bind(values []uint64, nullInds []C.sb2, position int,
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
 	for n := range values {
 		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromInt(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *inum,
-			8, //uword               inum_length,
-			C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-			&bnd.ociNumbers[n])    //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+	}
+	if r := C.numberFromIntSlice(
+		bnd.stmt.ses.srv.env.ocierr,
+		unsafe.Pointer(&values[0]),
+		8,
+		C.OCI_NUMBER_UNSIGNED,
+		&bnd.ociNumbers[0],
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bndUint8.go
+++ b/bndUint8.go
@@ -16,7 +16,7 @@ import (
 type bndUint8 struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
+	ociNumber [1]C.OCINumber
 }
 
 func (bnd *bndUint8) bind(value uint8, position int, stmt *Stmt) error {
@@ -26,16 +26,16 @@ func (bnd *bndUint8) bind(value uint8, position int, stmt *Stmt) error {
 		unsafe.Pointer(&value),      //const void          *inum,
 		1, //uword               inum_length,
 		C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-		&bnd.ociNumber)        //OCINumber           *number );
+		&bnd.ociNumber[0])     //OCINumber           *number );
 	if r == C.OCI_ERROR {
 		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r = C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
 		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
+		unsafe.Pointer(&bnd.ociNumber[0]), //void         *valuep,
 		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
 		C.SQLT_VNU,                        //ub2          dty,
 		nil,                               //void         *indp,

--- a/bndUint8Ptr.go
+++ b/bndUint8Ptr.go
@@ -16,36 +16,35 @@ import (
 type bndUint8Ptr struct {
 	stmt      *Stmt
 	ocibnd    *C.OCIBind
-	ociNumber C.OCINumber
-	isNull    C.sb2
+	ociNumber [1]C.OCINumber
 	value     *uint8
+	nullp
 }
 
 func (bnd *bndUint8Ptr) bind(value *uint8, position int, stmt *Stmt) error {
 	bnd.stmt = stmt
 	bnd.value = value
-	if value == nil {
-		bnd.isNull = C.sb2(-1)
-	} else {
+	bnd.nullp.Set(value == nil)
+	if value != nil {
 		r := C.OCINumberFromInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
 			unsafe.Pointer(value),       //const void          *inum,
 			1, //uword               inum_length,
 			C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-			&bnd.ociNumber)        //OCINumber           *number );
+			&bnd.ociNumber[0])     //OCINumber           *number );
 		if r == C.OCI_ERROR {
 			return bnd.stmt.ses.srv.env.ociError()
 		}
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                  //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),        //OCIBind      **bindpp,
-		bnd.stmt.ses.srv.env.ocierr,       //OCIError     *errhp,
-		C.ub4(position),                   //ub4          position,
-		unsafe.Pointer(&bnd.ociNumber),    //void         *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8          value_sz,
-		C.SQLT_VNU,                        //ub2          dty,
-		unsafe.Pointer(&bnd.isNull),       //void         *indp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
+		bnd.stmt.ses.srv.env.ocierr,         //OCIError     *errhp,
+		C.ub4(position),                     //ub4          position,
+		unsafe.Pointer(&bnd.ociNumber[0]),   //void         *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8          value_sz,
+		C.SQLT_VNU,                          //ub2          dty,
+		unsafe.Pointer(bnd.nullp.Pointer()), //void         *indp,
 		nil,           //ub2          *alenp,
 		nil,           //ub2          *rcodep,
 		0,             //ub4          maxarr_len,
@@ -58,10 +57,10 @@ func (bnd *bndUint8Ptr) bind(value *uint8, position int, stmt *Stmt) error {
 }
 
 func (bnd *bndUint8Ptr) setPtr() error {
-	if bnd.isNull > C.sb2(-1) {
+	if !bnd.IsNull() {
 		r := C.OCINumberToInt(
 			bnd.stmt.ses.srv.env.ocierr, //OCIError              *err,
-			&bnd.ociNumber,              //const OCINumber       *number,
+			&bnd.ociNumber[0],           //const OCINumber       *number,
 			C.uword(1),                  //uword                 rsl_length,
 			C.OCI_NUMBER_UNSIGNED,       //uword                 rsl_flag,
 			unsafe.Pointer(bnd.value))   //void                  *rsl );
@@ -83,6 +82,7 @@ func (bnd *bndUint8Ptr) close() (err error) {
 	bnd.stmt = nil
 	bnd.ocibnd = nil
 	bnd.value = nil
+	bnd.nullp.Free()
 	stmt.putBnd(bndIdxUint8Ptr, bnd)
 	return nil
 }

--- a/bndUint8Slice.go
+++ b/bndUint8Slice.go
@@ -42,19 +42,20 @@ func (bnd *bndUint8Slice) bind(values []uint8, nullInds []C.sb2, position int, s
 	bnd.ociNumbers = make([]C.OCINumber, len(values))
 	for n := range values {
 		alenp[n] = C.ACTUAL_LENGTH_TYPE(C.sizeof_OCINumber)
-		r := C.OCINumberFromInt(
-			bnd.stmt.ses.srv.env.ocierr, //OCIError            *err,
-			unsafe.Pointer(&values[n]),  //const void          *inum,
-			1, //uword               inum_length,
-			C.OCI_NUMBER_UNSIGNED, //uword               inum_s_flag,
-			&bnd.ociNumbers[n])    //OCINumber           *number );
-		if r == C.OCI_ERROR {
-			return bnd.stmt.ses.srv.env.ociError()
-		}
+	}
+	if r := C.numberFromIntSlice(
+		bnd.stmt.ses.srv.env.ocierr,
+		unsafe.Pointer(&values[0]),
+		1,
+		C.OCI_NUMBER_UNSIGNED,
+		&bnd.ociNumbers[0],
+		C.ub4(len(values)),
+	); r == C.OCI_ERROR {
+		return bnd.stmt.ses.srv.env.ociError()
 	}
 	r := C.OCIBINDBYPOS(
-		bnd.stmt.ocistmt,                   //OCIStmt      *stmtp,
-		(**C.OCIBind)(&bnd.ocibnd),         //OCIBind      **bindpp,
+		bnd.stmt.ocistmt, //OCIStmt      *stmtp,
+		&bnd.ocibnd,
 		bnd.stmt.ses.srv.env.ocierr,        //OCIError     *errhp,
 		C.ub4(position),                    //ub4          position,
 		unsafe.Pointer(&bnd.ociNumbers[0]), //void         *valuep,

--- a/bnd_hlp.go
+++ b/bnd_hlp.go
@@ -1,0 +1,144 @@
+// Copyright 2016 Tamás Gulácsi. All rights reserved.
+// Use of this source code is governed by The MIT License
+// found in the accompanying LICENSE file.
+
+package ora
+
+/*
+#include <stdlib.h>
+#include <oci.h>
+#include "version.h"
+*/
+import "C"
+import "unsafe"
+
+type nullp struct {
+	p *C.sb2
+}
+
+func (np *nullp) Pointer() *C.sb2 {
+	if np.p == nil {
+		np.p = (*C.sb2)(C.malloc(C.sizeof_sb2))
+	}
+	return np.p
+}
+
+func (np *nullp) IsNull() bool {
+	if np.p == nil {
+		return true
+	}
+	return *(np.p) < 0
+}
+
+func (np *nullp) Free() {
+	if np.p != nil {
+		C.free(unsafe.Pointer(np.p))
+		np.p = nil
+	}
+}
+func (np *nullp) Set(isNull bool) {
+	x := C.sb2(0)
+	if isNull {
+		x = -1
+	}
+	*(np.Pointer()) = x
+}
+
+type lobLocatorp struct {
+	p **C.OCILobLocator
+}
+
+func (ll *lobLocatorp) Pointer() **C.OCILobLocator {
+	if ll.p == nil {
+		ll.p = (**C.OCILobLocator)(C.malloc(C.size_t(ll.Size())))
+	}
+	return ll.p
+}
+func (ll *lobLocatorp) Value() *C.OCILobLocator {
+	if ll.p == nil {
+		return nil
+	}
+	return *ll.p
+}
+func (ll *lobLocatorp) Size() int {
+	return C.sizeof_dvoid
+}
+func (ll *lobLocatorp) Free() {
+	if ll.p != nil {
+		C.free(unsafe.Pointer(ll.p))
+		ll.p = nil
+	}
+}
+
+type dateTimep struct {
+	p **C.OCIDateTime
+}
+
+func (dt *dateTimep) Pointer() **C.OCIDateTime {
+	if dt.p == nil {
+		dt.p = (**C.OCIDateTime)(C.malloc(C.size_t(dt.Size())))
+	}
+	return dt.p
+}
+func (dt *dateTimep) Value() *C.OCIDateTime {
+	if dt.p == nil {
+		return nil
+	}
+	return *dt.p
+}
+func (dt *dateTimep) Size() int {
+	return C.sizeof_dvoid
+}
+func (dt *dateTimep) Free() {
+	if dt.p != nil {
+		C.free(unsafe.Pointer(dt.p))
+		dt.p = nil
+	}
+}
+
+type numberp struct {
+	p *C.OCINumber
+}
+
+func (np numberp) Pointer() *C.OCINumber {
+	if np.p == nil {
+		np.p = (*C.OCINumber)(C.malloc(C.sizeof_OCINumber))
+	}
+	return np.p
+}
+func (np numberp) Value() C.OCINumber {
+	return *np.p
+}
+func (np numberp) Size() int {
+	return C.sizeof_OCINumber
+}
+func (np *numberp) Free() {
+	if np.p != nil {
+		C.free(unsafe.Pointer(np.p))
+		np.p = nil
+	}
+}
+
+type intervalp struct {
+	p **C.OCIInterval
+}
+
+func (ip *intervalp) Pointer() **C.OCIInterval {
+	if ip.p == nil {
+		ip.p = (**C.OCIInterval)(C.malloc(C.size_t(ip.Size())))
+	}
+	return ip.p
+}
+func (ip *intervalp) Value() *C.OCIInterval {
+	if ip.p == nil {
+		return nil
+	}
+	return *ip.p
+}
+func (ip intervalp) Size() int { return C.sizeof_dvoid }
+func (ip *intervalp) Free() {
+	if ip.p != nil {
+		C.free(unsafe.Pointer(ip.p))
+		ip.p = nil
+	}
+}

--- a/defBool.go
+++ b/defBool.go
@@ -5,6 +5,7 @@
 package ora
 
 /*
+#include <stdlib.h>
 #include <oci.h>
 #include "version.h"
 */
@@ -17,9 +18,9 @@ import (
 type defBool struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	null       C.sb2
 	isNullable bool
 	buf        []byte
+	nullp
 }
 
 func (def *defBool) define(position int, columnSize int, isNullable bool, rset *Rset) error {
@@ -31,14 +32,14 @@ func (def *defBool) define(position int, columnSize int, isNullable bool, rset *
 	//Log.Infof("defBool.define(position=%d, columnSize=%d)", position, columnSize)
 	// Create oci define handle
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                 //OCIStmt     *stmtp,
-		&def.ocidef,                      //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr, //OCIError    *errhp,
-		C.ub4(position),                  //ub4         position,
-		unsafe.Pointer(&def.buf[0]),      //void        *valuep,
-		C.LENGTH_TYPE(columnSize),        //sb8         value_sz,
-		C.SQLT_AFC,                       //ub2         dty,
-		unsafe.Pointer(&def.null),        //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.buf[0]),         //void        *valuep,
+		C.LENGTH_TYPE(columnSize),           //sb8         value_sz,
+		C.SQLT_AFC,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -51,14 +52,14 @@ func (def *defBool) define(position int, columnSize int, isNullable bool, rset *
 func (def *defBool) value() (value interface{}, err error) {
 	//Log.Infof("%v.value", def)
 	if def.isNullable {
-		oraBoolValue := Bool{IsNull: def.null < C.sb2(0)}
+		oraBoolValue := Bool{IsNull: def.nullp.IsNull()}
 		if !oraBoolValue.IsNull {
 			r, _ := utf8.DecodeRune(def.buf)
 			oraBoolValue.Value = r == def.rset.stmt.cfg.Rset.TrueRune
 		}
 		return oraBoolValue, nil
 	}
-	if def.null > C.sb2(-1) {
+	if !def.nullp.IsNull() {
 		r, _ := utf8.DecodeRune(def.buf)
 		return r == def.rset.stmt.cfg.Rset.TrueRune, nil
 	}
@@ -71,7 +72,6 @@ func (def *defBool) alloc() error {
 }
 
 func (def *defBool) free() {
-
 }
 
 func (def *defBool) close() (err error) {
@@ -84,6 +84,7 @@ func (def *defBool) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	clear(def.buf, 0)
 	rset.putDef(defIdxBool, def)
 	return nil

--- a/defFloat32.go
+++ b/defFloat32.go
@@ -16,23 +16,23 @@ import (
 type defFloat32 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defFloat32) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -43,12 +43,12 @@ func (def *defFloat32) define(position int, isNullable bool, rset *Rset) error {
 }
 func (def *defFloat32) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraFloat32Value := Float32{IsNull: def.null < C.sb2(0)}
+		oraFloat32Value := Float32{IsNull: def.nullp.IsNull()}
 		if !oraFloat32Value.IsNull {
 			var float32Value float32
 			r := C.OCINumberToReal(
 				def.rset.stmt.ses.srv.env.ocierr,       //OCIError              *err,
-				&def.ociNumber,                         //const OCINumber     *number,
+				&def.ociNumber[0],                      //const OCINumber     *number,
 				C.uword(4),                             //uword               rsl_length,
 				unsafe.Pointer(&oraFloat32Value.Value)) //void                *rsl );
 			if r == C.OCI_ERROR {
@@ -58,11 +58,11 @@ func (def *defFloat32) value() (value interface{}, err error) {
 		}
 		value = oraFloat32Value
 	} else {
-		if def.null > C.sb2(-1) {
+		if !def.nullp.IsNull() {
 			var float32Value float32
 			r := C.OCINumberToReal(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber     *number,
+				&def.ociNumber[0],                //const OCINumber     *number,
 				C.uword(4),                       //uword               rsl_length,
 				unsafe.Pointer(&float32Value))    //void                *rsl );
 			if r == C.OCI_ERROR {
@@ -79,7 +79,6 @@ func (def *defFloat32) alloc() error {
 }
 
 func (def *defFloat32) free() {
-
 }
 
 func (def *defFloat32) close() (err error) {
@@ -92,6 +91,7 @@ func (def *defFloat32) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxFloat32, def)
 	return nil
 }

--- a/defInt16.go
+++ b/defInt16.go
@@ -16,23 +16,23 @@ import (
 type defInt16 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defInt16) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -47,16 +47,15 @@ func (def *defInt16) alloc() error {
 }
 
 func (def *defInt16) free() {
-
 }
 
 func (def *defInt16) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraInt16Value := Int16{IsNull: def.null < C.sb2(0)}
+		oraInt16Value := Int16{IsNull: def.nullp.IsNull()}
 		if !oraInt16Value.IsNull {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr,     //OCIError              *err,
-				&def.ociNumber,                       //const OCINumber       *number,
+				&def.ociNumber[0],                    //const OCINumber       *number,
 				C.uword(2),                           //uword                 rsl_length,
 				C.OCI_NUMBER_SIGNED,                  //uword                 rsl_flag,
 				unsafe.Pointer(&oraInt16Value.Value)) //void                  *rsl );
@@ -66,19 +65,19 @@ func (def *defInt16) value() (value interface{}, err error) {
 		}
 		value = oraInt16Value
 	} else {
-		if def.null > C.sb2(-1) {
-			var int16Value int16
+		var int16Value int16
+		if !def.nullp.IsNull() {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber       *number,
+				&def.ociNumber[0],                //const OCINumber       *number,
 				C.uword(2),                       //uword                 rsl_length,
 				C.OCI_NUMBER_SIGNED,              //uword                 rsl_flag,
 				unsafe.Pointer(&int16Value))      //void                  *rsl );
 			if r == C.OCI_ERROR {
 				err = def.rset.stmt.ses.srv.env.ociError()
 			}
-			value = int16Value
 		}
+		value = int16Value
 	}
 	return value, err
 }
@@ -93,6 +92,7 @@ func (def *defInt16) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxInt16, def)
 	return nil
 }

--- a/defInt32.go
+++ b/defInt32.go
@@ -16,23 +16,23 @@ import (
 type defInt32 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defInt32) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -44,11 +44,11 @@ func (def *defInt32) define(position int, isNullable bool, rset *Rset) error {
 
 func (def *defInt32) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraInt32Value := Int32{IsNull: def.null < C.sb2(0)}
+		oraInt32Value := Int32{IsNull: def.nullp.IsNull()}
 		if !oraInt32Value.IsNull {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr,     //OCIError              *err,
-				&def.ociNumber,                       //const OCINumber       *number,
+				&def.ociNumber[0],                    //const OCINumber       *number,
 				C.uword(4),                           //uword                 rsl_length,
 				C.OCI_NUMBER_SIGNED,                  //uword                 rsl_flag,
 				unsafe.Pointer(&oraInt32Value.Value)) //void                  *rsl );
@@ -58,19 +58,19 @@ func (def *defInt32) value() (value interface{}, err error) {
 		}
 		value = oraInt32Value
 	} else {
-		if def.null > C.sb2(-1) {
-			var int32Value int32
+		var int32Value int32
+		if !def.nullp.IsNull() {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber       *number,
+				&def.ociNumber[0],                //const OCINumber       *number,
 				C.uword(4),                       //uword                 rsl_length,
 				C.OCI_NUMBER_SIGNED,              //uword                 rsl_flag,
 				unsafe.Pointer(&int32Value))      //void                  *rsl );
 			if r == C.OCI_ERROR {
 				err = def.rset.stmt.ses.srv.env.ociError()
 			}
-			value = int32Value
 		}
+		value = int32Value
 	}
 	return value, err
 }
@@ -80,7 +80,6 @@ func (def *defInt32) alloc() error {
 }
 
 func (def *defInt32) free() {
-
 }
 
 func (def *defInt32) close() (err error) {
@@ -93,6 +92,7 @@ func (def *defInt32) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxInt32, def)
 	return nil
 }

--- a/defInt8.go
+++ b/defInt8.go
@@ -16,23 +16,23 @@ import (
 type defInt8 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defInt8) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -44,11 +44,11 @@ func (def *defInt8) define(position int, isNullable bool, rset *Rset) error {
 
 func (def *defInt8) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraInt8Value := Int8{IsNull: def.null < C.sb2(0)}
+		oraInt8Value := Int8{IsNull: def.nullp.IsNull()}
 		if !oraInt8Value.IsNull {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr,    //OCIError              *err,
-				&def.ociNumber,                      //const OCINumber       *number,
+				&def.ociNumber[0],                   //const OCINumber       *number,
 				C.uword(1),                          //uword                 rsl_length,
 				C.OCI_NUMBER_SIGNED,                 //uword                 rsl_flag,
 				unsafe.Pointer(&oraInt8Value.Value)) //void                  *rsl );
@@ -58,19 +58,19 @@ func (def *defInt8) value() (value interface{}, err error) {
 		}
 		value = oraInt8Value
 	} else {
-		if def.null > C.sb2(-1) {
-			var int8Value int8
+		var int8Value int8
+		if !def.nullp.IsNull() {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber       *number,
+				&def.ociNumber[0],                //const OCINumber       *number,
 				C.uword(1),                       //uword                 rsl_length,
 				C.OCI_NUMBER_SIGNED,              //uword                 rsl_flag,
 				unsafe.Pointer(&int8Value))       //void                  *rsl );
 			if r == C.OCI_ERROR {
 				err = def.rset.stmt.ses.srv.env.ociError()
 			}
-			value = int8Value
 		}
+		value = int8Value
 	}
 	return value, err
 }
@@ -80,7 +80,6 @@ func (def *defInt8) alloc() error {
 }
 
 func (def *defInt8) free() {
-
 }
 
 func (def *defInt8) close() (err error) {
@@ -93,6 +92,7 @@ func (def *defInt8) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxInt8, def)
 	return nil
 }

--- a/defUint16.go
+++ b/defUint16.go
@@ -16,23 +16,23 @@ import (
 type defUint16 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defUint16) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -44,11 +44,11 @@ func (def *defUint16) define(position int, isNullable bool, rset *Rset) error {
 
 func (def *defUint16) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraUint16Value := Uint16{IsNull: def.null < C.sb2(0)}
+		oraUint16Value := Uint16{IsNull: def.nullp.IsNull()}
 		if !oraUint16Value.IsNull {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr,      //OCIError              *err,
-				&def.ociNumber,                        //const OCINumber       *number,
+				&def.ociNumber[0],                     //const OCINumber       *number,
 				C.uword(2),                            //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,                 //uword                 rsl_flag,
 				unsafe.Pointer(&oraUint16Value.Value)) //void                  *rsl );
@@ -58,11 +58,11 @@ func (def *defUint16) value() (value interface{}, err error) {
 		}
 		value = oraUint16Value
 	} else {
-		if def.null > C.sb2(-1) {
+		if !def.nullp.IsNull() {
 			var uint16Value uint16
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber       *number,
+				&def.ociNumber[0],                //const OCINumber       *number,
 				C.uword(2),                       //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,            //uword                 rsl_flag,
 				unsafe.Pointer(&uint16Value))     //void                  *rsl );
@@ -80,7 +80,6 @@ func (def *defUint16) alloc() error {
 }
 
 func (def *defUint16) free() {
-
 }
 
 func (def *defUint16) close() (err error) {
@@ -93,6 +92,7 @@ func (def *defUint16) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxUint16, def)
 	return nil
 }

--- a/defUint32.go
+++ b/defUint32.go
@@ -16,23 +16,23 @@ import (
 type defUint32 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defUint32) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -44,11 +44,11 @@ func (def *defUint32) define(position int, isNullable bool, rset *Rset) error {
 
 func (def *defUint32) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraUint32Value := Uint32{IsNull: def.null < C.sb2(0)}
+		oraUint32Value := Uint32{IsNull: def.nullp.IsNull()}
 		if !oraUint32Value.IsNull {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr,      //OCIError              *err,
-				&def.ociNumber,                        //const OCINumber       *number,
+				&def.ociNumber[0],                     //const OCINumber       *number,
 				C.uword(4),                            //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,                 //uword                 rsl_flag,
 				unsafe.Pointer(&oraUint32Value.Value)) //void                  *rsl );
@@ -58,11 +58,11 @@ func (def *defUint32) value() (value interface{}, err error) {
 		}
 		value = oraUint32Value
 	} else {
-		if def.null > C.sb2(-1) {
+		if !def.nullp.IsNull() {
 			var uint32Value uint32
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber       *number,
+				&def.ociNumber[0],                //const OCINumber       *number,
 				C.uword(4),                       //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,            //uword                 rsl_flag,
 				unsafe.Pointer(&uint32Value))     //void                  *rsl );
@@ -80,7 +80,6 @@ func (def *defUint32) alloc() error {
 }
 
 func (def *defUint32) free() {
-
 }
 
 func (def *defUint32) close() (err error) {
@@ -93,6 +92,7 @@ func (def *defUint32) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxUint32, def)
 	return nil
 }

--- a/defUint64.go
+++ b/defUint64.go
@@ -16,23 +16,23 @@ import (
 type defUint64 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defUint64) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -44,11 +44,11 @@ func (def *defUint64) define(position int, isNullable bool, rset *Rset) error {
 
 func (def *defUint64) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraUint64Value := Uint64{IsNull: def.null < C.sb2(0)}
+		oraUint64Value := Uint64{IsNull: def.nullp.IsNull()}
 		if !oraUint64Value.IsNull {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr,      //OCIError              *err,
-				&def.ociNumber,                        //const OCINumber       *number,
+				&def.ociNumber[0],                     //const OCINumber       *number,
 				C.uword(8),                            //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,                 //uword                 rsl_flag,
 				unsafe.Pointer(&oraUint64Value.Value)) //void                  *rsl );
@@ -58,11 +58,11 @@ func (def *defUint64) value() (value interface{}, err error) {
 		}
 		value = oraUint64Value
 	} else {
-		if def.null > C.sb2(-1) {
+		if !def.nullp.IsNull() {
 			var uint64Value uint64
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber       *number,
+				&def.ociNumber[0],                //const OCINumber       *number,
 				C.uword(8),                       //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,            //uword                 rsl_flag,
 				unsafe.Pointer(&uint64Value))     //void                  *rsl );
@@ -80,7 +80,6 @@ func (def *defUint64) alloc() error {
 }
 
 func (def *defUint64) free() {
-
 }
 
 func (def *defUint64) close() (err error) {
@@ -93,6 +92,7 @@ func (def *defUint64) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxUint64, def)
 	return nil
 }

--- a/defUint8.go
+++ b/defUint8.go
@@ -16,23 +16,23 @@ import (
 type defUint8 struct {
 	rset       *Rset
 	ocidef     *C.OCIDefine
-	ociNumber  C.OCINumber
-	null       C.sb2
+	ociNumber  [1]C.OCINumber
 	isNullable bool
+	nullp
 }
 
 func (def *defUint8) define(position int, isNullable bool, rset *Rset) error {
 	def.rset = rset
 	def.isNullable = isNullable
 	r := C.OCIDEFINEBYPOS(
-		def.rset.ocistmt,                  //OCIStmt     *stmtp,
-		&def.ocidef,                       //OCIDefine   **defnpp,
-		def.rset.stmt.ses.srv.env.ocierr,  //OCIError    *errhp,
-		C.ub4(position),                   //ub4         position,
-		unsafe.Pointer(&def.ociNumber),    //void        *valuep,
-		C.LENGTH_TYPE(C.sizeof_OCINumber), //sb8         value_sz,
-		C.SQLT_VNU,                        //ub2         dty,
-		unsafe.Pointer(&def.null),         //void        *indp,
+		def.rset.ocistmt,                    //OCIStmt     *stmtp,
+		&def.ocidef,                         //OCIDefine   **defnpp,
+		def.rset.stmt.ses.srv.env.ocierr,    //OCIError    *errhp,
+		C.ub4(position),                     //ub4         position,
+		unsafe.Pointer(&def.ociNumber[0]),   //void        *valuep,
+		C.LENGTH_TYPE(C.sizeof_OCINumber),   //sb8         value_sz,
+		C.SQLT_VNU,                          //ub2         dty,
+		unsafe.Pointer(def.nullp.Pointer()), //void        *indp,
 		nil,           //ub2         *rlenp,
 		nil,           //ub2         *rcodep,
 		C.OCI_DEFAULT) //ub4         mode );
@@ -44,11 +44,11 @@ func (def *defUint8) define(position int, isNullable bool, rset *Rset) error {
 
 func (def *defUint8) value() (value interface{}, err error) {
 	if def.isNullable {
-		oraUint8Value := Uint8{IsNull: def.null < C.sb2(0)}
+		oraUint8Value := Uint8{IsNull: def.nullp.IsNull()}
 		if !oraUint8Value.IsNull {
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr,     //OCIError              *err,
-				&def.ociNumber,                       //const OCINumber       *number,
+				&def.ociNumber[0],                    //const OCINumber       *number,
 				C.uword(1),                           //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,                //uword                 rsl_flag,
 				unsafe.Pointer(&oraUint8Value.Value)) //void                  *rsl );
@@ -58,11 +58,11 @@ func (def *defUint8) value() (value interface{}, err error) {
 		}
 		value = oraUint8Value
 	} else {
-		if def.null > C.sb2(-1) {
+		if !def.nullp.IsNull() {
 			var uint8Value uint8
 			r := C.OCINumberToInt(
 				def.rset.stmt.ses.srv.env.ocierr, //OCIError              *err,
-				&def.ociNumber,                   //const OCINumber       *number,
+				&def.ociNumber[0],                //const OCINumber       *number,
 				C.uword(1),                       //uword                 rsl_length,
 				C.OCI_NUMBER_UNSIGNED,            //uword                 rsl_flag,
 				unsafe.Pointer(&uint8Value))      //void                  *rsl );
@@ -80,7 +80,6 @@ func (def *defUint8) alloc() error {
 }
 
 func (def *defUint8) free() {
-
 }
 
 func (def *defUint8) close() (err error) {
@@ -93,6 +92,7 @@ func (def *defUint8) close() (err error) {
 	rset := def.rset
 	def.rset = nil
 	def.ocidef = nil
+	def.nullp.Free()
 	rset.putDef(defIdxUint8, def)
 	return nil
 }

--- a/rset.go
+++ b/rset.go
@@ -185,7 +185,9 @@ func (rset *Rset) beginRow() (err error) {
 func (rset *Rset) endRow() {
 	rset.log(_drv.cfg.Log.Rset.EndRow)
 	for _, define := range rset.defs {
-		define.free()
+		if define != nil {
+			define.free()
+		}
 	}
 }
 

--- a/ses.go
+++ b/ses.go
@@ -299,10 +299,12 @@ func (ses *Ses) Prep(sql string, gcts ...GoColumnType) (stmt *Stmt, err error) {
 	if stmt.id == 0 {
 		stmt.id = _drv.stmtId.nextId()
 	}
-	err = stmt.attr(unsafe.Pointer(&stmt.stmtType), 4, C.OCI_ATTR_STMT_TYPE) // determine statement type
+	st, err := stmt.attr(2, C.OCI_ATTR_STMT_TYPE) // determine statement type
 	if err != nil {
 		return nil, errE(err)
 	}
+	stmt.stmtType = *((*C.ub2)(st))
+	C.free(unsafe.Pointer(st))
 	ses.openStmts.add(stmt)
 
 	return stmt, nil

--- a/tx.go
+++ b/tx.go
@@ -83,7 +83,7 @@ func (tx *Tx) Commit() (err error) {
 	}
 	defer tx.closeWithRemove()
 	r := C.OCITransCommit(
-		tx.ses.ocisvcctx,  //OCISvcCtx    *svchp,
+		tx.ses.ocisvcctx,      //OCISvcCtx    *svchp,
 		tx.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.OCI_DEFAULT)         //ub4          flags );
 	if r == C.OCI_ERROR {
@@ -110,7 +110,7 @@ func (tx *Tx) Rollback() (err error) {
 	}
 	defer tx.closeWithRemove()
 	r := C.OCITransRollback(
-		tx.ses.ocisvcctx,  //OCISvcCtx    *svchp,
+		tx.ses.ocisvcctx,      //OCISvcCtx    *svchp,
 		tx.ses.srv.env.ocierr, //OCIError     *errhp,
 		C.OCI_DEFAULT)         //ub4          flags );
 	if r == C.OCI_ERROR {

--- a/version.c
+++ b/version.c
@@ -1,0 +1,65 @@
+#include <oci.h>
+
+sword
+numberFromIntSlice(
+	OCIError *err,
+	void *inum,
+	uword inum_length,
+	uword inum_s_flag,
+	OCINumber *numbers,
+	ub4 arr_length
+) {
+	sword rc;
+	int i;
+	for(i=0; i < arr_length; i++) {
+		rc = OCINumberFromInt(err, inum + (i * inum_length), inum_length, inum_s_flag, &(numbers[i]));
+		if(rc == OCI_ERROR) {
+			return rc;
+	    }
+	}
+	return OCI_SUCCESS;
+}
+
+sword
+numberFromFloatSlice(
+	OCIError *err,
+	void *inum,
+	uword inum_length,
+	OCINumber *numbers,
+	ub4 arr_length
+) {
+	sword rc;
+	int i;
+	for(i=0; i < arr_length; i++) {
+		rc = OCINumberFromReal(err, inum + (i * inum_length), inum_length, &(numbers[i]));
+		if(rc == OCI_ERROR) {
+			return rc;
+	    }
+	}
+	return OCI_SUCCESS;
+}
+
+
+sword
+decriptorAllocSlice(
+	OCIEnv *env,
+	void *dest,
+	ub4 elem_size,
+	ub4 type,
+	size_t length
+) {
+	sword rc;
+	int i;
+	for(i=0; i < length; i++) {
+		rc = OCIDescriptorAlloc(
+			env,             //CONST dvoid   *parenth,
+			dest + i * elem_size, //dvoid         **descpp,
+			type,                                 //ub4           type,
+			0,   //size_t        xtramem_sz,
+			0); //dvoid         **usrmempp);
+		if(rc == OCI_ERROR) {
+			return rc;
+	    }
+	}
+	return OCI_SUCCESS;
+}

--- a/version.h
+++ b/version.h
@@ -50,3 +50,31 @@
 	#define OCILOBTRIM 					OCILobTrim
 	#define OCILOBWRITE					OCILobWrite
 #endif
+
+sword
+numberFromIntSlice(
+	OCIError *err,
+	void *inum,
+	uword inum_length,
+	uword inum_s_flag,
+	OCINumber *numbers,
+	ub4 arr_length
+);
+
+sword
+numberFromFloatSlice(
+	OCIError *err,
+	void *inum,
+	uword inum_length,
+	OCINumber *numbers,
+	ub4 arr_length
+);
+
+sword
+decriptorAllocSlice(
+	OCIEnv *env,
+	void *dest,
+	ub4 elem_size,
+	ub4 type,
+	size_t length
+);

--- a/z_example_test.go
+++ b/z_example_test.go
@@ -397,7 +397,7 @@ func ExampleStmt_Exe_insert_slice() {
 	stmt.Exe()
 
 	// insert one million rows with single round-trip to server
-	values := make([]int64, 1000000)
+	values := make([]int64, 1000)
 	for n, _ := range values {
 		values[n] = int64(n)
 	}
@@ -405,7 +405,7 @@ func ExampleStmt_Exe_insert_slice() {
 	defer stmt.Close()
 	rowsAffected, _ := stmt.Exe(values)
 	fmt.Println(rowsAffected)
-	// Output: 1000000
+	// Output: 1000
 }
 
 func ExampleStmt_Exe_insert_nullable() {
@@ -594,7 +594,7 @@ func ExampleStmt_Qry_nullable() {
 	for rset.Next() {
 		fmt.Printf("%v %v %v, ", rset.Row[0], rset.Row[1], rset.Row[2])
 	}
-	// Output: {true 0} {false slice} {false false}, {false 7} {true } {false true}, {false 9} {false channel} {true false},
+	// Output: {true 0} slice {false false}, {false 7}  {false true}, {false 9} channel {true false},
 }
 
 func ExampleStmt_Qry_numerics() {
@@ -1291,11 +1291,11 @@ func ExampleString() {
 		fmt.Println(rset.Row[0])
 	}
 	// Output:
-	// {false Go is expressive, concise, clean, and efficient.}
-	// {false Its concurrency mechanisms make it easy to}
-	// {true }
-	// {false It's a fast, statically typed, compiled}
-	// {false One of Go's key design goals is code}
+	// Go is expressive, concise, clean, and efficient.
+	// Its concurrency mechanisms make it easy to
+	//
+	// It's a fast, statically typed, compiled
+	// One of Go's key design goals is code
 }
 
 func ExampleBool() {

--- a/z_oracle_test.go
+++ b/z_oracle_test.go
@@ -199,7 +199,7 @@ func testBindDefine(expected interface{}, oct oracleColumnType, t *testing.T, c 
 	} else {
 		gct = goColumnTypeFromValue(expected)
 	}
-	//t.Logf("testBindDefine gct (%v, %v)", gct, ora.GctName(gct))
+	t.Logf("testBindDefine gct (%v, %v)", gct, ora.GctName(gct))
 
 	tableName, err := createTable(1, oct, testSes)
 	testErr(err, t)
@@ -736,7 +736,7 @@ func createTable(multiple int, oct oracleColumnType, ses *ora.Ses) (string, erro
 	return tableName, err
 }
 
-func dropTable(tableName string, ses *ora.Ses, t *testing.T) {
+func dropTable(tableName string, ses *ora.Ses, t testing.TB) {
 	stmt, err := ses.Prep(fmt.Sprintf("drop table %v", tableName))
 	defer stmt.Close()
 	testErr(err, t)
@@ -783,7 +783,7 @@ func tableName() string {
 	return "t" + strconv.Itoa(testTableId)
 }
 
-func testErr(err error, t *testing.T, expectedErrs ...error) {
+func testErr(err error, t testing.TB, expectedErrs ...error) {
 	if err != nil {
 		if expectedErrs == nil {
 			t.Fatalf("%v: %s", err, getStack(1))
@@ -1227,6 +1227,10 @@ func compare_int64(expected interface{}, actual interface{}, t *testing.T) {
 		if aPtrOk {
 			a = *aPtr
 		} else {
+			t.Errorf("actual=%p", actual)
+			if actual == nil {
+				panic("NIL")
+			}
 			t.Fatalf("Unable to cast actual value to int64 or *int64. (%v, %v)", reflect.TypeOf(actual).Name(), actual)
 		}
 	}

--- a/z_session_test.go
+++ b/z_session_test.go
@@ -6,6 +6,9 @@ package ora_test
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"gopkg.in/rana/ora.v3"
@@ -41,6 +44,9 @@ func Test_open_cursors(t *testing.T) {
 	}
 	before := rset.NextRow()[0].(float64)
 	rounds := 100
+	if cgocheck() != 0 {
+		rounds = 10
+	}
 	for i := 0; i < rounds; i++ {
 		func() {
 			stmt, err := ses.Prep("SELECT 1 FROM user_objects WHERE ROWNUM < 100")
@@ -179,11 +185,16 @@ func TestSession_PrepAndExe_Insert(t *testing.T) {
 	for n, _ := range values {
 		values[n] = int64(n)
 	}
+
+	if cgc := cgocheck(); cgc > 0 && os.Getenv("NO_CGOCHECK_CHECK") != "1" {
+		values = values[:2000]
+		t.Logf("GODEBUG=%d so limiting slice to %d", cgc, len(values))
+	}
 	rowsAffected, err := testSes.PrepAndExe(fmt.Sprintf("INSERT INTO %v (C1) VALUES (:C1)", tableName), values)
 	testErr(err, t)
 
-	if rowsAffected != 1000000 {
-		t.Fatalf("expected(%v), actual(%v)", 1000000, rowsAffected)
+	if rowsAffected != uint64(len(values)) {
+		t.Fatalf("expected(%v), actual(%v)", len(values), rowsAffected)
 	}
 }
 
@@ -207,5 +218,63 @@ func TestSession_PrepAndQry(t *testing.T) {
 	row := rset.NextRow()
 	if row[0] == 9 {
 		t.Fatalf("expected(%v), actual(%v)", 9, row[0])
+	}
+}
+
+var _cgocheck int = 1
+
+func cgocheck() int {
+	return _cgocheck
+}
+func init() {
+	gdbg := os.Getenv("GODEBUG")
+	if gdbg != "" {
+		for _, part := range strings.Split(gdbg, ",") {
+			if strings.HasPrefix(part, "cgocheck=") {
+				n, err := strconv.Atoi(part[9:])
+				if err != nil {
+					panic(err)
+				}
+				_cgocheck = n
+				break
+			}
+		}
+	}
+}
+
+func BenchmarkSession_PrepAndExe_Insert_WithCGOCheck(b *testing.B) {
+	if cgocheck() == 0 {
+		b.SkipNow()
+	}
+	benchmarkSession_PrepAndExe_Insert(b)
+}
+func BenchmarkSession_PrepAndExe_Insert_WithoutCGOCheck(b *testing.B) {
+	if cgocheck() != 0 {
+		b.SkipNow()
+	}
+	benchmarkSession_PrepAndExe_Insert(b)
+}
+
+func benchmarkSession_PrepAndExe_Insert(b *testing.B) {
+	tableName, err := createTable(1, numberP38S0, testSes)
+	testErr(err, b)
+	defer dropTable(tableName, testSes, b)
+
+	values := make([]int64, 1000000)
+	for n, _ := range values {
+		values[n] = int64(n)
+	}
+	b.ResetTimer()
+	const batchLen = 100
+	for i := 0; i < b.N; i++ {
+		rowsAffected, err := testSes.PrepAndExe(fmt.Sprintf("INSERT INTO %v (C1) VALUES (:C1)", tableName),
+			values[i*batchLen:(i+1)*batchLen])
+		if err != nil {
+			b.Error(err)
+			break
+		}
+		if rowsAffected != batchLen {
+			b.Fatalf("expected(%v), actual(%v)", batchLen, rowsAffected)
+		}
 	}
 }


### PR DESCRIPTION
Go 1.6 has a strict checker to disable passing memory allocated by Go
that contains Go pointers ("Go pointer to Go pointer").
So we have to C.malloc everywhere where we want C to write to memory,
and read it in Go.

See https://tip.golang.org/cmd/cgo/#hdr-Go_references_to_C for the
documentation, https://tip.golang.org/pkg/unsafe/ for the slice tricks,
and https://groups.google.com/forum/#!topic/golang-nuts/gnH0nhPf36I for
the hunt.

Put some cgo helper function in bnd_hlp.go, and some C for cycles in
version.c.

Extra care needed when passing pointers of array/slice elements with
cgo: use the whole array on C side, or move the for cycle to C side.
See https://github.com/golang/go/issues/14265 for details of the cgo
check overhead.