### PR TITLE
Adding cgo pkg-config to ora.go

### DIFF
--- a/ora.go
+++ b/ora.go
@@ -7,6 +7,8 @@ package ora
 /*
 #include <oci.h>
 #include <stdlib.h>
+
+#cgo pkg-config: oci8
 */
 import "C"
 import (


### PR DESCRIPTION
This very small commit makes this package much easier to use when compiling. You just need to have the oci8.pc in your pkg-config path. Please see the attached oci8.pc example. Unfortunately, oracle does not include this by default with their devel package (although they should). I don't do a lot of development on Windows, but my understanding is that pkg-config is bundled with the mingw32 tools and should work there.

Alternatively, if this is breaks things for windows, I would suggest adding the pkg-config entry in a go source with a build tag (filename or otherwise ...).

