### PR TITLE
Removes automatic detection of bool values

### DIFF
--- a/rset.go
+++ b/rset.go
@@ -469,49 +469,32 @@ func (rset *Rset) open(stmt *Stmt, ocistmt *C.OCIStmt) error {
 			}
 		case C.SQLT_AFC:
 			rset.logF(_drv.cfg.Log.Rset.OpenDefs, "%d. AFC size=%d", n+1, columnSize)
-			//Log.Infof("rset AFC size=%d gct=%v", columnSize, gct)
 			// CHAR, NCHAR
-			// for char(1 char) columns, columnSize is 4 (AL32UTF8 charset)
-			if columnSize == 1 || columnSize == 4 {
-				if stmt.gcts == nil || n >= len(stmt.gcts) || stmt.gcts[n] == D {
-					gct = rset.stmt.cfg.Rset.char1
-					rset.logF(_drv.cfg.Log.Rset.OpenDefs, "%d. AFC no gct, char1=%s", n+1, gct)
-				} else {
-					err = checkBoolOrStringColumn(stmt.gcts[n])
-					if err != nil {
-						return err
-					}
-					gct = stmt.gcts[n]
-				}
-				rset.logF(_drv.cfg.Log.Rset.OpenDefs, "%d. AFC gct=%s", n+1, gct)
-				switch gct {
-				case B, OraB:
-					// Interpret single char as bool
-					isNullable := false
-					if gct == OraB {
-						isNullable = true
-					}
-					def := rset.getDef(defIdxBool).(*defBool)
-					rset.defs[n] = def
-					err = def.define(n+1, int(columnSize), isNullable, rset)
-					if err != nil {
-						return err
-					}
-				case S, OraS:
-					// Interpret single char as string
-					rset.defineString(n, columnSize, gct)
-				}
+			if stmt.gcts == nil || n >= len(stmt.gcts) || stmt.gcts[n] == D {
+				gct = rset.stmt.cfg.Rset.char
 			} else {
-				// Interpret as string
-				if stmt.gcts == nil || n >= len(stmt.gcts) || stmt.gcts[n] == D {
-					gct = rset.stmt.cfg.Rset.char
-				} else {
-					err = checkStringColumn(stmt.gcts[n])
-					if err != nil {
-						return err
-					}
-					gct = stmt.gcts[n]
+				err = checkBoolOrStringColumn(stmt.gcts[n])
+				if err != nil {
+					return err
 				}
+				gct = stmt.gcts[n]
+			}
+			rset.logF(_drv.cfg.Log.Rset.OpenDefs, "%d. AFC gct=%s", n+1, gct)
+			switch gct {
+			case B, OraB:
+				// Interpret single char as bool
+				isNullable := false
+				if gct == OraB {
+					isNullable = true
+				}
+				def := rset.getDef(defIdxBool).(*defBool)
+				rset.defs[n] = def
+				err = def.define(n+1, int(columnSize), isNullable, rset)
+				if err != nil {
+					return err
+				}
+			case S, OraS:
+				// Interpret single char as string
 				err = rset.defineString(n, columnSize, gct)
 				if err != nil {
 					return err


### PR DESCRIPTION
Bool values do not exist on Oracle. Assuming something with a character is a bool value breaks a lot of valid scenarios where columns have a single char value and are not boolean values.

Examples of problematic queries are:
SELECT 'a' FROM DUAL;
SELECT 'ABCD' FROM DUAL;