### PR TITLE
Reset autoclose flag after getting from pool.

### DIFF
--- a/defRset.go
+++ b/defRset.go
@@ -32,6 +32,7 @@ func (def *defRset) define(position int, rset *Rset) error {
 		if result.id == 0 {
 			result.id = _drv.rsetId.nextId()
 		}
+		result.autoClose = false
 		result.stmt = rset.stmt
 		result.ocistmt = rset.ocistmt
 		def.result[i] = result


### PR DESCRIPTION
Otherwise, it will close statement with first nested rset.