### PR TITLE
Potential memory leak in method Ses.Prep

### DIFF
--- a/ses.go
+++ b/ses.go
@@ -305,12 +305,7 @@ func (ses *Ses) Prep(sql string, gcts ...GoColumnType) (stmt *Stmt, err error) {
 	if err != nil {
 		return nil, errE(err)
 	}
-	// allocate statement handle
-	upOciStmt, err := ses.srv.env.allocOciHandle(C.OCI_HTYPE_STMT)
-	if err != nil {
-		return nil, errE(err)
-	}
-	ocistmt := (*C.OCIStmt)(upOciStmt)
+	ocistmt := (*C.OCIStmt)(nil)
 	cSql := C.CString(sql) // prepare sql text with statement handle
 	defer C.free(unsafe.Pointer(cSql))
 	r := C.OCIStmtPrepare2(


### PR DESCRIPTION
Removed OCIHandleAlloc when using OCIStmtPrepare2.

Oracle documentation says: A call to OCIStmtPrepare2(), even if the session
does not have a statement cache, will also allocate the statement handle and
therefore applications using only OCIStmtPrepare2() must not call
OCIHandleAlloc() for the statement handle.

See: https://docs.oracle.com/cd/B19306_01/appdev.102/b14250/oci09adv.htm