### PR TITLE
use pkg-config for cgo command

### DIFF
--- a/env_posix.go
+++ b/env_posix.go
@@ -6,5 +6,5 @@
 
 package ora
 
-// #cgo LDFLAGS: -lclntsh
+// #cgo pkgk-config: oci8
 import "C"


### PR DESCRIPTION
removes extra `-lclntsh` from compiler invocation