### PR TITLE
Explicitly free OCI handles to avoid memory leaks.

### DIFF
--- a/env.go
+++ b/env.go
@@ -107,8 +107,11 @@ func (env *Env) Close() (err error) {
 	env.openSrvs.closeAll(errs)
 
 	// Free oci environment handle and all oci child handles
-	// The oci error handle is released as a child of the environment handle
 	err = env.freeOciHandle(unsafe.Pointer(env.ocienv), C.OCI_HTYPE_ENV)
+	if err != nil {
+		return errE(err)
+	}
+	err = env.freeOciHandle(unsafe.Pointer(env.ocierr), C.OCI_HTYPE_ERROR)
 	if err != nil {
 		return errE(err)
 	}

--- a/ses.go
+++ b/ses.go
@@ -199,7 +199,6 @@ func (ses *Ses) close() (err error) {
 		return nil
 	}
 	// close session
-	// OCISessionEnd invalidates oci session handle; no need to free session.ocises
 	r := C.OCISessionEnd(
 		ses.ocisvcctx,      //OCISvcCtx       *svchp,
 		ses.srv.env.ocierr, //OCIError        *errhp,
@@ -208,6 +207,15 @@ func (ses *Ses) close() (err error) {
 	if r == C.OCI_ERROR {
 		errs.PushBack(errE(ses.srv.env.ociError()))
 	}
+	err = ses.srv.env.freeOciHandle(unsafe.Pointer(ses.ocises), C.OCI_HTYPE_SESSION)
+	if err != nil {
+		return errE(err)
+	}
+	err = ses.srv.env.freeOciHandle(unsafe.Pointer(ses.ocisvcctx), C.OCI_HTYPE_SVCCTX)
+	if err != nil {
+	return errE(err)
+	}
+
 	return nil
 }
 

--- a/srv.go
+++ b/srv.go
@@ -119,8 +119,6 @@ func (srv *Srv) close() (err error) {
 	srv.openSess.closeAll(errs) // close sessions
 
 	// detach server
-	// OCIServerDetach invalidates oci server handle; no need to free server.ocisvr
-	// OCIServerDetach invalidates oci service context handle; no need to free server.ocisvcctx
 	r := C.OCIServerDetach(
 		srv.ocisrv,     //OCIServer   *srvhp,
 		srv.env.ocierr, //OCIError    *errhp,
@@ -128,6 +126,11 @@ func (srv *Srv) close() (err error) {
 	if r == C.OCI_ERROR {
 		errs.PushBack(errE(srv.env.ociError()))
 	}
+	err = srv.env.freeOciHandle(unsafe.Pointer(srv.ocisrv), C.OCI_HTYPE_SERVER)
+	if err != nil {
+		return errE(err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Leak less when connecting and disconnecting repeatedly.