### PR TITLE
Update example in README.md to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Package ora implements an Oracle database driver.
     import (
     	"database/sql"
 
-    	_ "gopkg.in/rana/ora.v4"
+    	"gopkg.in/rana/ora.v4"
     )
 
     func main() {


### PR DESCRIPTION
`ora` is now used in the example for `ora.WithStmtCfg`, so its import shouldn't use the blank identifier.