### PR TITLE
Force maxfetch len

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/rset.go
+++ b/rset.go
@@ -527,11 +527,9 @@ Loop:
 		switch param.typeCode {
 		// These can consume a lot of memory.
 		case C.SQLT_LNG, C.SQLT_BFILE, C.SQLT_BLOB, C.SQLT_CLOB, C.SQLT_LBI:
-			if !stmt.Cfg().ForceMaxFetchSize() {
+			if !stmt.SelfCfg().ForceMaxFetchSize() {
 				fetchLen = MinFetchLen
 				break Loop
-			} else {
-				fmt.Println("forced MaxFetchLen")
 			}
 		}
 	}

--- a/rset.go
+++ b/rset.go
@@ -521,13 +521,18 @@ func (rset *Rset) open(stmt *Stmt, ocistmt *C.OCIStmt) error {
 	}
 
 	fetchLen := MaxFetchLen
+
 Loop:
 	for _, param := range params {
 		switch param.typeCode {
 		// These can consume a lot of memory.
 		case C.SQLT_LNG, C.SQLT_BFILE, C.SQLT_BLOB, C.SQLT_CLOB, C.SQLT_LBI:
-			fetchLen = MinFetchLen
-			break Loop
+			if !stmt.Cfg().ForceMaxFetchSize() {
+				fetchLen = MinFetchLen
+				break Loop
+			} else {
+				fmt.Println("forced MaxFetchLen")
+			}
 		}
 	}
 

--- a/stmt.go
+++ b/stmt.go
@@ -95,6 +95,17 @@ func (stmt *Stmt) Cfg() StmtCfg {
 	}
 	return cfg
 }
+
+// returns the Stmt's StmtCfg only
+func (stmt *Stmt) SelfCfg() StmtCfg {
+	var cfg StmtCfg
+	c := stmt.cfg.Load()
+	if c != nil {
+		cfg = c.(StmtCfg)
+	}
+	return cfg
+}
+
 func (stmt *Stmt) SetCfg(cfg StmtCfg) {
 	stmt.cfg.Store(cfg)
 }
@@ -388,7 +399,6 @@ func (stmt *Stmt) qry(params []interface{}) (rset *Rset, err error) {
 	return stmt.qryC(context.Background(), params)
 }
 func (stmt *Stmt) qryC(ctx context.Context, params []interface{}) (rset *Rset, err error) {
-	fmt.Printf("in qryC\n")
 	defer func() {
 		if value := recover(); value != nil {
 			err = errR(value)

--- a/stmt.go
+++ b/stmt.go
@@ -388,6 +388,7 @@ func (stmt *Stmt) qry(params []interface{}) (rset *Rset, err error) {
 	return stmt.qryC(context.Background(), params)
 }
 func (stmt *Stmt) qryC(ctx context.Context, params []interface{}) (rset *Rset, err error) {
+	fmt.Printf("in qryC\n")
 	defer func() {
 		if value := recover(); value != nil {
 			err = errR(value)
@@ -400,6 +401,7 @@ func (stmt *Stmt) qryC(ctx context.Context, params []interface{}) (rset *Rset, e
 	if cfg, ok := ctxStmtCfg(ctx); ok {
 		stmt.SetCfg(cfg)
 	}
+
 	err = stmt.checkClosed()
 	if err != nil {
 		return nil, errE(err)
@@ -409,6 +411,7 @@ func (stmt *Stmt) qryC(ctx context.Context, params []interface{}) (rset *Rset, e
 		return nil, errE(err)
 	}
 	err = stmt.setPrefetchSize() // set prefetch size
+
 	if err != nil {
 		return nil, errE(err)
 	}

--- a/stmtCfg.go
+++ b/stmtCfg.go
@@ -18,7 +18,7 @@ type StmtCfg struct {
 	longRawBufferSize   uint32
 	lobBufferSize       int
 	stringPtrBufferSize int
-	forceMaxFetchSize	bool
+	forceMaxFetchLen    bool
 	byteSlice           GoColumnType
 
 	// IsAutoCommitting determines whether DML statements are automatically
@@ -259,12 +259,19 @@ func (c StmtCfg) ByteSlice() GoColumnType {
 	return c.byteSlice
 }
 
+// returns a value of the forceMaxFetchLen
 func (c StmtCfg) ForceMaxFetchSize() bool {
-	return c.forceMaxFetchSize
+	return c.forceMaxFetchLen
 }
 
-func (c StmtCfg) SetForceMaxFetchSize()  StmtCfg {
-	c.forceMaxFetchSize = true
+// Sets the flag forceMaxFetchLen to true which causes the
+// result sets containing columns o types:
+// C.SQLT_LNG, C.SQLT_BFILE, C.SQLT_BLOB, C.SQLT_CLOB, C.SQLT_LBI
+// to be fetched with MaxFetchLen
+// Caution: the default buffer size for blob is 1MB. So, for example a single
+// fetch from the result set that contains just one blob will consume 128MB of RAM
+func (c StmtCfg) SetForceMaxFetchLen() StmtCfg {
+	c.forceMaxFetchLen = true
 	return c
 }
 

--- a/stmtCfg.go
+++ b/stmtCfg.go
@@ -18,6 +18,7 @@ type StmtCfg struct {
 	longRawBufferSize   uint32
 	lobBufferSize       int
 	stringPtrBufferSize int
+	forceMaxFetchSize	bool
 	byteSlice           GoColumnType
 
 	// IsAutoCommitting determines whether DML statements are automatically
@@ -256,6 +257,15 @@ func (c StmtCfg) SetByteSlice(gct GoColumnType) StmtCfg {
 // if the destination column is NUMBER, BINARY_DOUBLE, BINARY_FLOAT or FLOAT.
 func (c StmtCfg) ByteSlice() GoColumnType {
 	return c.byteSlice
+}
+
+func (c StmtCfg) ForceMaxFetchSize() bool {
+	return c.forceMaxFetchSize
+}
+
+func (c StmtCfg) SetForceMaxFetchSize()  StmtCfg {
+	c.forceMaxFetchSize = true
+	return c
 }
 
 func (c StmtCfg) SetNumberInt(gct GoColumnType) StmtCfg {


### PR DESCRIPTION
This branch allows the user to enforce the maximum fetch length even in case that the result set contains BLOBs.
The way to do it is:
ctx, _ := context.WithTimeout(context.Background(), 10*time.Minute)
ctx = ora.WithStmtCfg(ctx, ora.Cfg().StmtCfg.SetForceMaxFetchLen())

If SetForceMaxFetchLength isn't called, the previously existing behavior is preserved.




