### PR TITLE
fix race condition when context is cancelled after function returns

### DIFF
--- a/conn_go1_8.go
+++ b/conn_go1_8.go
@@ -85,7 +85,7 @@ func (con *Con) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, 
 		return nil, err
 	}
 	var tx *Tx
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		defer close(done)
 		var err error
@@ -94,12 +94,18 @@ func (con *Con) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, 
 	}()
 	var err error
 	select {
-	case <-ctx.Done():
-		if err = ctx.Err(); isCanceled(err) {
-			con.ses.Break()
-		}
 	case err = <-done:
 		return tx, err
+	case <-ctx.Done():
+		// select again to avoid race condition if both are done
+		select {
+		case err = <-done:
+			return tx, err
+		default:
+			if err = ctx.Err(); isCanceled(err) {
+				con.ses.Break()
+			}
+		}
 	}
 	return nil, maybeBadConn(err)
 }


### PR DESCRIPTION
Same thing as the other drivers, this race condition occurs when you `defer cancel()` a context.  Even if the query is finished and has even returned, if the scheduler doesn't schedule the break goroutine until after the context is cancelled then you have a 50% chance of calling Break when you shouldn't.
Solves the other half of https://github.com/rana/ora/issues/234

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rana/ora/235)
<!-- Reviewable:end -->
